### PR TITLE
fix: 새 문서 생성 요청 완료 시 입력창 초기화

### DIFF
--- a/src/components/common/document/CreateDocument.jsx
+++ b/src/components/common/document/CreateDocument.jsx
@@ -112,7 +112,7 @@ const CreateDocument = () => {
       onSuccess: () => {},
       onError: (error) => {
         alert("문서 생성에 실패했습니다. 관리자에게 문의하세요.");
-        console.log(error);
+        console.error(error);
       },
     });
   };

--- a/src/components/common/document/DocsList.jsx
+++ b/src/components/common/document/DocsList.jsx
@@ -31,10 +31,16 @@ const DocsList = ({ data }) => {
 
   const { mutate: createScrap } = useMutation({
     mutationFn: scrapCreate,
+    onError: (error) => {
+      console.error(error);
+    },
   });
 
   const { mutate: deleteScrap } = useMutation({
     mutationFn: scrapDelete,
+    onError: (error) => {
+      console.error(error);
+    },
   });
 
   const handleOnScrap = (el, scrap) => {

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -157,7 +157,6 @@ const Document = ({ id }) => {
     if (!getLat) {
       addressInfo = docsLocation;
     }
-
     return addressInfo;
   };
 
@@ -173,10 +172,7 @@ const Document = ({ id }) => {
       docsRequestLocation: addressInfo,
     });
 
-    toast.info("관리자 승인 후 갱신됩니다.", {
-      position: "top-right",
-      autoClose: 3000,
-    });
+    toast.info("관리자 승인 후 갱신됩니다.");
   };
 
   const handleBasicCancel = () => {
@@ -187,15 +183,13 @@ const Document = ({ id }) => {
     setValue(updateValue);
   };
 
-  // 내용버튼 컨트롤
-
   const handleInputContent = () => {
     setEditContent(true);
   };
 
   const handleContentSave = () => {
-    mutationContentModify({ docs_id: id, docsContent: value });
     setEditContent(false);
+    mutationContentModify({ docs_id: id, docsContent: value });
     toast.success("내용이 수정되었습니다!", {
       position: "top-right",
       autoClose: 3000,
@@ -212,25 +206,22 @@ const Document = ({ id }) => {
 
   const { mutate: scrapDetailCreate } = useMutation({
     mutationFn: scrapCreate,
+    onError: (error) => {
+      console.error(error);
+    },
   });
 
   const { mutate: scrapDetailDelete } = useMutation({
     mutationFn: scrapDelete,
+    onError: (error) => {
+      console.error(error);
+    },
   });
 
   useEffect(() => {
     if (scrap) {
       scrapDetailCreate({ docsId: id });
-      toast("스크랩 되었습니다!", {
-        position: "top-right",
-        autoClose: 5000,
-        hideProgressBar: false,
-        closeOnClick: true,
-        pauseOnHover: true,
-        draggable: true,
-        progress: undefined,
-        theme: "light",
-      });
+      toast("스크랩 되었습니다!");
     } else {
       scrapDetailDelete({ docsId: id });
     }

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -21,6 +21,15 @@ import "react-toastify/dist/ReactToastify.css";
 import ScrapBtn from "./ScrapBtn";
 import { useEffect } from "react";
 import { scrapCreate, scrapDelete } from "../../../services/scrap";
+import { IoIosArrowForward } from "react-icons/io";
+
+const StyledIcon = styled(IoIosArrowForward)`
+  z-index: 10000;
+  height: 100%;
+  /* position: absolute; */
+  /* position: relative; */
+  /* left: 20rem; */
+`;
 
 const Group = styled.div`
   height: 100%;
@@ -55,6 +64,12 @@ const Group = styled.div`
     height: fit-content;
     margin-top: -4rem;
   }
+`;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const Box = styled.div`
@@ -235,112 +250,118 @@ const Document = ({ id }) => {
         theme="light"
       />
 
-      <Group>
-        <BasicInfo>
-          <DocumentHeading
-            className="basic"
-            type={edit}
-            save={save}
-            cancel={cancel}
-            onClick={handleInput}
-            onBasicSave={handleBasicSave}
-            onBasicCancel={handleBasicCancel}
-          >
-            기본 정보
-          </DocumentHeading>
-          <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
-        </BasicInfo>
-        <Box>
-          <InfoGroup htmlFor="title" label="문서 제목">
-            {edit ? (
-              <StyledInput
-                htmlFor="docsName"
-                id="docsName"
-                placeholder={docsName}
-                value={valueInit.docsName}
-                onChange={handleOnChange}
-              />
-            ) : (
-              docsName
-            )}
-          </InfoGroup>
-
-          <InfoGroup className="location" htmlFor="location" label="위치">
-            {edit ? (
-              <StyledInput
-                htmlFor="docsLocation"
-                id="docsLocation"
-                placeholder={initialAddress}
-                value={address}
-                disabled
-                onChange={handleOnChange}
-              />
-            ) : (
-              initialAddress
-            )}
-          </InfoGroup>
-          <InfoGroup htmlFor="category" label="카테고리">
-            {edit ? (
-              <StyledSpan>
-                <SelectMenu
-                  id="docsCategory"
-                  placeholder={valueInit.docsCategory}
-                  value={category}
+      <Container>
+        <Group>
+          <BasicInfo>
+            <DocumentHeading
+              className="basic"
+              type={edit}
+              save={save}
+              cancel={cancel}
+              onClick={handleInput}
+              onBasicSave={handleBasicSave}
+              onBasicCancel={handleBasicCancel}
+            >
+              기본 정보
+            </DocumentHeading>
+            <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
+          </BasicInfo>
+          <Box>
+            <InfoGroup htmlFor="title" label="문서 제목">
+              {edit ? (
+                <StyledInput
+                  htmlFor="docsName"
+                  id="docsName"
+                  placeholder={docsName}
+                  value={valueInit.docsName}
                   onChange={handleOnChange}
                 />
-              </StyledSpan>
+              ) : (
+                docsName
+              )}
+            </InfoGroup>
+
+            <InfoGroup className="location" htmlFor="location" label="위치">
+              {edit ? (
+                <StyledInput
+                  htmlFor="docsLocation"
+                  id="docsLocation"
+                  placeholder={initialAddress}
+                  value={address}
+                  disabled
+                  onChange={handleOnChange}
+                />
+              ) : (
+                initialAddress
+              )}
+            </InfoGroup>
+
+            <InfoGroup htmlFor="category" label="카테고리">
+              {edit ? (
+                <StyledSpan>
+                  <SelectMenu
+                    id="docsCategory"
+                    placeholder={valueInit.docsCategory}
+                    value={category}
+                    onChange={handleOnChange}
+                  />
+                </StyledSpan>
+              ) : (
+                docsCategory
+              )}
+            </InfoGroup>
+          </Box>
+          <ContentHeading>
+            <DocumentHeading
+              className="content"
+              contentType={editContent}
+              onClick={handleInputContent}
+              onSave={handleSave}
+              onCancel={handleCancel}
+            >
+              내용
+            </DocumentHeading>
+            <DocumentTime className="time">{docsCreatedAt}</DocumentTime>
+          </ContentHeading>
+          <Description>
+            {editContent ? (
+              <EditorContainer className="container">
+                <MDEditor
+                  value={value || value === "" ? value : docsContent}
+                  onChange={handleOnContentChange}
+                  preview="edit"
+                  components={{
+                    toolbar: (command, disabled, executeCommand) => {
+                      if (command.keyCommand === "code") {
+                        return (
+                          <button
+                            aria-label="Insert code"
+                            disabled={disabled}
+                            onClick={(evn) => {
+                              evn.stopPropagation();
+                              executeCommand(command, command.groupName);
+                            }}
+                          >
+                            Code
+                          </button>
+                        );
+                      }
+                    },
+                  }}
+                />
+              </EditorContainer>
             ) : (
-              docsCategory
-            )}
-          </InfoGroup>
-        </Box>
-        <ContentHeading>
-          <DocumentHeading
-            className="content"
-            contentType={editContent}
-            onClick={handleInputContent}
-            onSave={handleSave}
-            onCancel={handleCancel}
-          >
-            내용
-          </DocumentHeading>
-          <DocumentTime className="time">{docsCreatedAt}</DocumentTime>
-        </ContentHeading>
-        <Description>
-          {editContent ? (
-            <EditorContainer className="container">
-              <MDEditor
-                value={value || value === "" ? value : docsContent}
-                onChange={handleOnContentChange}
-                preview="edit"
-                components={{
-                  toolbar: (command, disabled, executeCommand) => {
-                    if (command.keyCommand === "code") {
-                      return (
-                        <button
-                          aria-label="Insert code"
-                          disabled={disabled}
-                          onClick={(evn) => {
-                            evn.stopPropagation();
-                            executeCommand(command, command.groupName);
-                          }}
-                        >
-                          Code
-                        </button>
-                      );
-                    }
-                  },
-                }}
+              <MDEditor.Markdown
+                source={docsContent}
+                style={{ whiteSpace: "pre-wrap" }}
               />
-            </EditorContainer>
-          ) : (
-            <MDEditor.Markdown
-              source={docsContent}
-              style={{ whiteSpace: "pre-wrap" }}
-            />
-          )}
-        </Description>
-      </Group>
+            )}
+          </Description>
+        </Group>
+        <div>
+          <StyledIcon />
+        </div>
+      </Container>
     </>
   );
 };

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -205,6 +205,16 @@ const Document = ({ id }) => {
   useEffect(() => {
     if (scrap) {
       scrapDetailCreate({ docsId: id });
+      toast("스크랩 되었습니다!", {
+        position: "top-right",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+        theme: "light",
+      });
     } else {
       scrapDetailDelete({ docsId: id });
     }

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -12,21 +12,20 @@ import {
   basicModify,
 } from "../../../services/document";
 import { useSelector } from "react-redux";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import MDEditor from "@uiw/react-md-editor";
 import useInput from "../../../hooks/useInput";
 import Skeleton from "../layout/Skeleton";
 import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import ScrapBtn from "./ScrapBtn";
-import { useEffect } from "react";
 import { scrapCreate, scrapDelete } from "../../../services/scrap";
 import { IoIosArrowForward } from "react-icons/io";
 
 const StyledIcon = styled(IoIosArrowForward)`
   z-index: 10000;
-  position: relative;
-  left: 20rem;
+  /* position: relative; */
+  /* left: 20rem; */
 `;
 
 const Group = styled.div`
@@ -102,7 +101,6 @@ const BasicInfo = styled.div`
 `;
 
 const Document = ({ id }) => {
-  // 데이터 요청
   const { data, isLoading, isError } = useQuery(["detail_document", id], () =>
     detailDocument(id)
   );
@@ -110,14 +108,10 @@ const Document = ({ id }) => {
   const category = useSelector((state) => state.category.category);
   let getLat = useSelector((state) => state.latLng.latitude);
   let getLng = useSelector((state) => state.latLng.longitude);
-
-  // 데이터 선언
-  const docsName = data?.data.response.docsName;
-  const docsCategory = data?.data.response.docsCategory;
-  const docsCreatedAt = data?.data.response.docsCreatedAt;
-  let docsContent = data?.data.response.docsContent;
-
   let { address, initialAddress } = useSelector((state) => state.address);
+
+  const { docsName, docsCategory, docsCreatedAt, docsContent } =
+    data?.data.response || {};
 
   const { valueInit, handleOnChange, reset } = useInput({
     docsCategory,

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -121,8 +121,8 @@ const Document = ({ id }) => {
     docsContent,
   });
 
-  const [edit, setEdit] = useState(false); // 기본정보 컨트롤 (수정버튼 눌렀을 경우와 누르지 않았을 경우)
-  let [value, setValue] = useState(docsContent);
+  const [basicEdit, setBasicEdit] = useState(false);
+  const [contentValue, setContentValue] = useState(docsContent);
   const [editContent, setEditContent] = useState(false);
   const [scrap, setScrap] = useState(false);
 
@@ -149,7 +149,7 @@ const Document = ({ id }) => {
   });
 
   const handleSetInput = () => {
-    setEdit(true);
+    setBasicEdit(true);
     valueInit.docsName = docsName;
   };
 
@@ -161,7 +161,7 @@ const Document = ({ id }) => {
   };
 
   const handleBasicSave = () => {
-    setEdit(false);
+    setBasicEdit(false);
     handleAddressInfo();
 
     mutationBasicModify({
@@ -176,20 +176,21 @@ const Document = ({ id }) => {
   };
 
   const handleBasicCancel = () => {
-    setEdit(false);
+    setBasicEdit(false);
   };
 
   const handleOnContentChange = (updateValue) => {
-    setValue(updateValue);
+    setContentValue(updateValue);
   };
 
   const handleInputContent = () => {
     setEditContent(true);
+    setContentValue(docsContent);
   };
 
   const handleContentSave = () => {
     setEditContent(false);
-    mutationContentModify({ docs_id: id, docsContent: value });
+    mutationContentModify({ docs_id: id, docsContent: contentValue });
     toast.success("내용이 수정되었습니다!");
   };
 
@@ -244,7 +245,7 @@ const Document = ({ id }) => {
           <BasicInfo>
             <DocumentHeading
               className="basic"
-              type={edit}
+              type={basicEdit}
               clickEdit={handleSetInput}
               basicSave={handleBasicSave}
               basicCancel={handleBasicCancel}
@@ -256,7 +257,7 @@ const Document = ({ id }) => {
 
           <Box>
             <InfoGroup htmlFor="title" label="문서 제목">
-              {edit ? (
+              {basicEdit ? (
                 <StyledInput
                   htmlFor="docsName"
                   id="docsName"
@@ -269,7 +270,7 @@ const Document = ({ id }) => {
               )}
             </InfoGroup>
             <InfoGroup className="location" htmlFor="location" label="위치">
-              {edit ? (
+              {basicEdit ? (
                 <StyledInput
                   htmlFor="docsLocation"
                   id="docsLocation"
@@ -283,7 +284,7 @@ const Document = ({ id }) => {
               )}
             </InfoGroup>
             <InfoGroup htmlFor="category" label="카테고리">
-              {edit ? (
+              {basicEdit ? (
                 <StyledSpan>
                   <SelectMenu
                     id="docsCategory"
@@ -315,7 +316,7 @@ const Document = ({ id }) => {
             {editContent ? (
               <EditorContainer className="container">
                 <MDEditor
-                  value={value || value === "" ? value : docsContent}
+                  value={contentValue}
                   onChange={handleOnContentChange}
                   preview="edit"
                   components={{

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -190,10 +190,7 @@ const Document = ({ id }) => {
   const handleContentSave = () => {
     setEditContent(false);
     mutationContentModify({ docs_id: id, docsContent: value });
-    toast.success("내용이 수정되었습니다!", {
-      position: "top-right",
-      autoClose: 3000,
-    });
+    toast.success("내용이 수정되었습니다!");
   };
 
   const handleContentcCancel = () => {

--- a/src/components/common/document/Document.jsx
+++ b/src/components/common/document/Document.jsx
@@ -25,10 +25,8 @@ import { IoIosArrowForward } from "react-icons/io";
 
 const StyledIcon = styled(IoIosArrowForward)`
   z-index: 10000;
-  height: 100%;
-  /* position: absolute; */
-  /* position: relative; */
-  /* left: 20rem; */
+  position: relative;
+  left: 20rem;
 `;
 
 const Group = styled.div`

--- a/src/components/common/document/DocumentHeading.jsx
+++ b/src/components/common/document/DocumentHeading.jsx
@@ -24,14 +24,14 @@ const StyledHeading = styled.p`
 
 const DocumentHeading = ({
   children,
-  onClick,
+  clickEdit,
   type = false,
   contentType = false,
   className,
-  onSave,
-  onCancel,
-  onBasicSave,
-  onBasicCancel,
+  contentSave,
+  contentCancel,
+  basicSave,
+  basicCancel,
 }) => {
   return (
     <>
@@ -40,15 +40,15 @@ const DocumentHeading = ({
         {className === "basic" ? (
           <>
             {type === false ? (
-              <span className="icon" onClick={onClick}>
+              <span className="icon" onClick={clickEdit}>
                 편집
               </span>
             ) : (
               <>
-                <span className="icon save" onClick={onBasicSave}>
+                <span className="icon save" onClick={basicSave}>
                   저장
                 </span>
-                <span className="icon cancel" onClick={onBasicCancel}>
+                <span className="icon cancel" onClick={basicCancel}>
                   취소
                 </span>
               </>
@@ -57,15 +57,15 @@ const DocumentHeading = ({
         ) : (
           <>
             {contentType === false ? (
-              <span className="icon" onClick={onClick}>
+              <span className="icon" onClick={clickEdit}>
                 편집
               </span>
             ) : (
               <>
-                <span className="icon save" onClick={onSave}>
+                <span className="icon save" onClick={contentSave}>
                   저장
                 </span>
-                <span className="icon cancel" onClick={onCancel}>
+                <span className="icon cancel" onClick={contentCancel}>
                   취소
                 </span>
               </>


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

- 새 문서 생성 요청 완료 시 입력창 초기화
- 문서 생성 api요청을 mutate를 사용하여 변경
- CreateDocument 컴포넌트에서 alert창 로직을 함수로 선언
- 기본 정보에서 위치를 수정하지 않았을 때 위치가 빈 배열로 바뀌는 문제 수정
- 내용 변경 취소 후 다시 편집 했을 때 에디터에 취소했던 내용이 반영되어 있는 문제 해결
- 기본 정보 수정에 대한 변수 이름 변경
- 변수, 함수 이름 수정 (리팩토링)