### PR TITLE
refactor: mutation 커스텀 훅, alert/toast 함수 분리, 사이드바 prop 변경

### DIFF
--- a/src/components/common/layout/Header.jsx
+++ b/src/components/common/layout/Header.jsx
@@ -1,10 +1,8 @@
 import styled from "styled-components";
 import mainLogo from "/main-logo.png";
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Button from "./Button";
 import routes from "@/routes";
-import Swal from "sweetalert2";
 import { SlLogout } from "react-icons/sl";
 import SearchBar from "@/components/search/SearchBar";
 import { getUserInfo } from "@/services/mypage";
@@ -12,6 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import { logoutState } from "@/store/userReducer";
 import { useDispatch, useSelector } from "react-redux";
 import { Cookies } from "react-cookie";
+import { popUpLogout } from "@/utils/alert";
 
 const Header = () => {
   const navigate = useNavigate();
@@ -25,18 +24,6 @@ const Header = () => {
     select: (data) => data?.data?.response.nickName,
   });
 
-  const popUpLogout = () => {
-    return Swal.fire({
-      icon: "question",
-      text: "로그아웃 하시겠습니까?",
-      showCancelButton: true,
-      confirmButtonText: "예",
-      cancelButtonText: "아니오",
-      confirmButtonColor: "#429f50",
-      cancelButtonColor: "#d33",
-    });
-  };
-
   const logOutUser = () => {
     localStorage.clear();
     dispatch(logoutState());
@@ -44,18 +31,24 @@ const Header = () => {
     location.reload();
   };
 
+  const clickLogout = () => {
+    popUpLogout().then((result) => {
+      if (result.isConfirmed) {
+        logOutUser();
+      }
+    });
+  };
+
+  const reloadHome = () => {
+    navigate(routes.home);
+    location.reload();
+  };
+
   return (
     <>
       <Container>
         <HeaderDiv>
-          <LogoImg
-            src={mainLogo}
-            alt="jnu-logo"
-            onClick={() => {
-              navigate(routes.home);
-              location.reload();
-            }}
-          />
+          <LogoImg src={mainLogo} alt="jnu-logo" onClick={reloadHome} />
           <SearchBar />
           {!user.isLogin ? (
             <ButtonGroup>
@@ -79,16 +72,7 @@ const Header = () => {
             <ButtonGroup>
               <NameInfo>
                 <div>{nickName}</div>
-                <button
-                  className="logout-btn"
-                  onClick={() => {
-                    popUpLogout().then((result) => {
-                      if (result.isConfirmed) {
-                        logOutUser();
-                      }
-                    });
-                  }}
-                >
+                <button className="logout-btn" onClick={clickLogout}>
                   <SlLogout size={"21px"} />
                 </button>
               </NameInfo>

--- a/src/components/common/layout/MainLayout.jsx
+++ b/src/components/common/layout/MainLayout.jsx
@@ -1,10 +1,14 @@
 import Sidebar from "./Sidebar";
 import Header from "./Header";
 
-const MainLayout = ({ viewActive, myActive, children, onClick }) => {
+const MainLayout = ({ children, onClick, isActive, myPageClicked }) => {
   return (
     <>
-      <Sidebar viewActive={viewActive} myActive={myActive} onClick={onClick} />
+      <Sidebar
+        onClick={onClick}
+        isActive={isActive}
+        myPageClicked={myPageClicked}
+      />
       <Header />
       {children}
     </>

--- a/src/components/common/layout/MypageSidebar.jsx
+++ b/src/components/common/layout/MypageSidebar.jsx
@@ -3,7 +3,8 @@ import routes from "@/routes";
 import { NavLink } from "react-router-dom";
 
 const ListBox = styled.div`
-  background-color: rgba(222, 233, 224, 0.27);
+  background-color: ${(props) =>
+    props.isActive === true && "rgba(222, 233, 224, 0.27)"};
   position: relative;
   bottom: 0.5rem;
 `;
@@ -39,9 +40,9 @@ const MyList = styled(NavLink)`
 
   cursor: pointer;
 `;
-const MypageSidebar = ({ isActive, onClick }) => {
+const MypageSidebar = ({ isActive }) => {
   return (
-    <ListBox onClick={onClick}>
+    <ListBox isActive={isActive}>
       <MyList to={routes.myPage}>- 회원정보 수정</MyList>
       <MyList to={routes.scrap} id={isActive && "active"}>
         - 스크랩

--- a/src/components/common/layout/MypageSidebar.jsx
+++ b/src/components/common/layout/MypageSidebar.jsx
@@ -39,11 +39,11 @@ const MyList = styled(NavLink)`
 
   cursor: pointer;
 `;
-const MypageSidebar = ({ scrapActive }) => {
+const MypageSidebar = ({ isActive, onClick }) => {
   return (
-    <ListBox>
+    <ListBox onClick={onClick}>
       <MyList to={routes.myPage}>- 회원정보 수정</MyList>
-      <MyList className={scrapActive ? "active" : ""} to={routes.scrap}>
+      <MyList to={routes.scrap} id={isActive && "active"}>
         - 스크랩
       </MyList>
     </ListBox>

--- a/src/components/common/layout/Sidebar.jsx
+++ b/src/components/common/layout/Sidebar.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import styled from "styled-components";
 import routes from "@/routes";
 import MenuList from "./SidebarList";
@@ -6,8 +5,8 @@ import { GoHomeFill } from "react-icons/go";
 import { FaPenSquare } from "react-icons/fa";
 import { HiMiniUserGroup } from "react-icons/hi2";
 import { AiTwotoneSetting } from "react-icons/ai";
-import { useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
+
 const Container = styled.div`
   width: 15rem;
   height: 100vh;
@@ -26,10 +25,9 @@ const Container = styled.div`
   z-index: 3;
 `;
 
-function Sidebar({ viewActive, adminActive, myActive, scrapActive }) {
+function Sidebar({ isActive, myPageClicked, onClick }) {
   const user = useSelector((state) => state.user);
   const { role } = user;
-  //회원정보 가져오기, 이때 회원정보 중
 
   return (
     <Container>
@@ -37,31 +35,31 @@ function Sidebar({ viewActive, adminActive, myActive, scrapActive }) {
         name="홈"
         icons={<GoHomeFill />}
         route={routes.home}
-        isActive={viewActive}
+        onClick={onClick}
+        isActive={isActive}
       ></MenuList>
 
       <MenuList
         name="게시글 작성"
         icons={<FaPenSquare />}
         route={routes.addPost}
+        onClick={onClick}
       ></MenuList>
 
       <MenuList
         name="마이페이지"
         icons={<HiMiniUserGroup />}
         route={routes.myPage}
-        isActive={myActive}
-        scrapActive={scrapActive}
+        myPageClicked={myPageClicked}
       ></MenuList>
 
-      {role === "ADMIN" ? (
+      {role === "ADMIN" && (
         <MenuList
           name="관리자"
           icons={<AiTwotoneSetting />}
           route={routes.admin}
-          isActive={adminActive}
         ></MenuList>
-      ) : null}
+      )}
     </Container>
   );
 }

--- a/src/components/common/layout/SidebarList.jsx
+++ b/src/components/common/layout/SidebarList.jsx
@@ -12,16 +12,17 @@ export const MenuIcon = styled.div`
 const MenuList = ({ name, icons, route, isActive, myPageClicked, onClick }) => {
   const [clicked, setClicked] = useState(myPageClicked);
   const [act, setAct] = useState(isActive);
+
   const handleOnClick = (e) => {
     e.preventDefault();
-    setClicked(true);
+    setClicked((prev) => !prev);
   };
 
   useEffect(() => {
     if (clicked) {
       setAct(true);
     }
-  }, [clicked]);
+  }, []);
 
   return (
     <>
@@ -35,7 +36,7 @@ const MenuList = ({ name, icons, route, isActive, myPageClicked, onClick }) => {
             <BsFillCaretDownFill className="icon" onClick={handleOnClick} />
           ))}
       </NavStyle>
-      {clicked && <MypageSidebar isActive={isActive} />}
+      {clicked && <MypageSidebar isActive={act} />}
     </>
   );
 };

--- a/src/components/common/layout/SidebarList.jsx
+++ b/src/components/common/layout/SidebarList.jsx
@@ -2,53 +2,40 @@ import styled from "styled-components";
 import { NavLink } from "react-router-dom";
 import MypageSidebar from "./MypageSidebar";
 import { BsFillCaretDownFill, BsFillCaretUpFill } from "react-icons/bs";
-import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { notClickState, onClickState } from "../../../store/sidebar";
+import { useState, useEffect } from "react";
 
 export const MenuIcon = styled.div`
   font-size: 2rem;
   padding: 0 1rem;
 `;
 
-const MenuList = ({ name, icons, route, isActive, scrapActive }) => {
-  const act = isActive;
-  const dispatch = useDispatch();
-  const click = useSelector((state) => state.sidebar.click);
-  // const [click, setClick] = useState(false);
-  const clickDown = (e) => {
-    console.log(e.target);
-    // setClick(!click);
-    click ? dispatch(notClickState()) : dispatch(onClickState());
-
-    console.log(click);
+const MenuList = ({ name, icons, route, isActive, myPageClicked, onClick }) => {
+  const [clicked, setClicked] = useState(myPageClicked);
+  const [act, setAct] = useState(isActive);
+  const handleOnClick = (e) => {
+    e.preventDefault();
+    setClicked(true);
   };
+
+  useEffect(() => {
+    if (clicked) {
+      setAct(true);
+    }
+  }, [clicked]);
+
   return (
     <>
-      <NavStyle to={route} id={act ? "active" : null}>
+      <NavStyle to={route} id={act ? "active" : null} onClick={onClick}>
         <MenuIcon>{icons}</MenuIcon>
         {name}
-        {name === "마이페이지" ? (
-          click ? (
-            <BsFillCaretUpFill className="icon" onClick={(e) => clickDown(e)} />
+        {name === "마이페이지" &&
+          (clicked ? (
+            <BsFillCaretUpFill className="icon" onClick={handleOnClick} />
           ) : (
-            <BsFillCaretDownFill
-              className="icon"
-              onClick={(e) => clickDown(e)}
-            />
-          )
-        ) : (
-          <></>
-        )}
+            <BsFillCaretDownFill className="icon" onClick={handleOnClick} />
+          ))}
       </NavStyle>
-      {name === "마이페이지" && (
-        <>
-          {click && <MypageSidebar scrapActive={scrapActive}></MypageSidebar>}
-          {/* {isActive ? (
-            <MypageSidebar scrapActive={scrapActive}></MypageSidebar>
-          ) : null} */}
-        </>
-      )}
+      {clicked && <MypageSidebar isActive={isActive} />}
     </>
   );
 };

--- a/src/components/document/CreateDocument.jsx
+++ b/src/components/document/CreateDocument.jsx
@@ -10,7 +10,7 @@ import { create } from "@/services/document";
 import { useDispatch, useSelector } from "react-redux";
 import Swal from "sweetalert2";
 import { useMutation } from "@tanstack/react-query";
-import { toast, ToastContainer } from "react-toastify";
+import { askAlert, cancelAlert, requestAlert } from "@/utils/alert";
 
 export const Container = styled.div`
   width: 20rem;
@@ -66,44 +66,6 @@ const CreateDocument = () => {
     mutationFn: create,
   });
 
-  const swalWithBootstrapButtons = Swal.mixin({
-    customClass: {
-      confirmButton: "btn btn-success",
-      cancelButton: "btn btn-danger",
-    },
-    buttonsStyling: true,
-  });
-
-  const askAlert = () => {
-    return swalWithBootstrapButtons.fire({
-      title: "문서를 등록하시겠습니까?",
-      html: `문서제목: ${inputData.docsName}<br/>
-      위치: ${address}<br/>
-      카테고리: ${inputData.docsCategory}`,
-      icon: "warning",
-      showCancelButton: true,
-      confirmButtonText: "등록 요청",
-      cancelButtonText: "취소",
-      reverseButtons: true,
-    });
-  };
-
-  const cancelAlert = () => {
-    swalWithBootstrapButtons.fire(
-      "취소 완료",
-      "문서 등록 요청을 취소합니다.",
-      "error"
-    );
-  };
-
-  const requestAlert = () => {
-    swalWithBootstrapButtons.fire(
-      "문서 등록 요청 완료!",
-      "관리자의 승인 후 등록이 완료됩니다.",
-      "success"
-    );
-  };
-
   const handleClear = () => {
     reset();
     dispatch({ type: "clearAddress" });
@@ -127,32 +89,15 @@ const CreateDocument = () => {
   };
 
   const handleRegisterAlert = () => {
-    if (inputData.docsName && inputData.docsLocation.lat) {
-      askAlert().then((result) => {
-        if (result.isConfirmed) {
-          sendRequest();
+    if (inputData.docsName !== "" && inputData.docsLocation.lat !== "") {
+      askAlert(inputData.docsName, address, inputData.docsCategory).then(
+        (result) => {
+          if (result.isConfirmed) {
+            sendRequest();
+          }
         }
-      });
+      );
     }
-  };
-
-  const handleNullToken = () => {
-    toast.warning("로그인 후 작성 가능합니다.");
-  };
-
-  const handleDisabled = () => {
-    return (
-      <Button
-        color="primary"
-        border="1px solid"
-        border-color="primary"
-        backgroundcolor="white"
-        disabled
-        onClick={handleCancel}
-      >
-        등록 취소
-      </Button>
-    );
   };
 
   const handleCancel = () => {

--- a/src/components/document/CreateDocument.jsx
+++ b/src/components/document/CreateDocument.jsx
@@ -8,9 +8,10 @@ import useInput from "@/hooks/useInput";
 import useValidation from "@/hooks/useValidation";
 import { create } from "@/services/document";
 import { useDispatch, useSelector } from "react-redux";
-import Swal from "sweetalert2";
 import { useMutation } from "@tanstack/react-query";
 import { askAlert, cancelAlert, requestAlert } from "@/utils/alert";
+import { nullTokenWrite, occurError } from "@/utils/toast";
+import { ToastContainer } from "react-toastify";
 
 export const Container = styled.div`
   width: 20rem;
@@ -79,9 +80,9 @@ const CreateDocument = () => {
       },
       onError: (error) => {
         if (!isLogin) {
-          alert("로그인 후 이용 가능합니다.");
+          nullTokenWrite();
         } else {
-          alert("문서 생성에 실패했습니다. 관리자에게 문의하세요.");
+          occurError();
           console.error(error);
         }
       },
@@ -100,17 +101,17 @@ const CreateDocument = () => {
     }
   };
 
-  const handleCancel = () => {
-    if (!isLogin) handleDisabled();
-    if (!inputData.docsName && !inputData.docsLocation) handleDisabled();
-    else {
+  const handleCancel = (e) => {
+    if (inputData.docsName === "" || inputData.docsLocation === "") {
+      e.preventDefault();
+    } else {
       cancelAlert();
       handleClear();
     }
   };
 
   const handleSubmit = () => {
-    if (!isLogin) handleNullToken();
+    if (!isLogin) nullTokenWrite();
     else {
       handleSetNameMsg("docsName", valueInit.docsName);
       handleSetLocationMsg("docsLocation", { lat: latitude, lng: longitude });
@@ -120,17 +121,7 @@ const CreateDocument = () => {
 
   return (
     <>
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="light"
-      />
+      <ToastContainer />
       <Container>
         <DocumentInputGroup
           htmlFor="docsName"

--- a/src/components/document/CreateDocument.jsx
+++ b/src/components/document/CreateDocument.jsx
@@ -3,7 +3,7 @@ import DocumentInputGroup from "./DocumentInputGroup";
 import DocumentLabel from "./DocumentLabel";
 import SelectMenu from "./SelectMenu";
 import Button from "@/components/common/layout/Button";
-import { helperMsg } from "@/constant/helpermsg";
+import { HELPER_MSG } from "@/constant/helpermsg";
 import useInput from "@/hooks/useInput";
 import useValidation from "@/hooks/useValidation";
 import { create } from "@/services/document";
@@ -126,7 +126,7 @@ const CreateDocument = () => {
         <DocumentInputGroup
           htmlFor="docsName"
           id="docsName"
-          placeholder={helperMsg.title}
+          placeholder={HELPER_MSG.TITLE}
           value={valueInit.docsName}
           onChange={(e) => {
             handleOnChange(e);
@@ -139,7 +139,7 @@ const CreateDocument = () => {
         <DocumentInputGroup
           htmlFor="docsLocation"
           id="docsLocation"
-          placeholder={helperMsg.location}
+          placeholder={HELPER_MSG.LOCATION}
           value={address}
           disabled
           onChange={handleOnChange}

--- a/src/components/document/CreateDocument.jsx
+++ b/src/components/document/CreateDocument.jsx
@@ -52,7 +52,6 @@ const CreateDocument = () => {
     docsName: "",
     docsLocation: "",
   });
-
   const inputData = {
     docsCategory: category || "카페",
     docsName: valueInit.docsName,
@@ -90,7 +89,7 @@ const CreateDocument = () => {
   };
 
   const handleRegisterAlert = () => {
-    if (inputData.docsName !== "" && inputData.docsLocation.lat !== "") {
+    if (inputData.docsName && inputData.docsLocation.lat) {
       askAlert(inputData.docsName, address, inputData.docsCategory).then(
         (result) => {
           if (result.isConfirmed) {
@@ -126,7 +125,7 @@ const CreateDocument = () => {
         <DocumentInputGroup
           htmlFor="docsName"
           id="docsName"
-          placeholder={HELPER_MSG.TITLE}
+          placeholder={HELPER_MSG.NAME}
           value={valueInit.docsName}
           onChange={(e) => {
             handleOnChange(e);

--- a/src/components/document/DocsItem.jsx
+++ b/src/components/document/DocsItem.jsx
@@ -34,7 +34,14 @@ const StyledHr = styled.hr`
   margin: 1.4rem 0;
 `;
 
-const DocsItem = ({ name, category, isScraped, onClick, onScrapClick }) => {
+const DocsItem = ({
+  name,
+  category,
+  isScraped,
+  onClick,
+  onScrapClick,
+  children,
+}) => {
   const [scrap, setScrap] = useState(isScraped);
 
   const handleOnScrapFill = (e) => {
@@ -45,14 +52,20 @@ const DocsItem = ({ name, category, isScraped, onClick, onScrapClick }) => {
 
   return (
     <>
-      <Container onClick={onClick}>
-        <div className="title">
-          <div>{name}</div>
-          <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
-        </div>
-        <span className="category">{category}</span>
-      </Container>
-      <StyledHr />
+      {name ? (
+        <>
+          <Container onClick={onClick}>
+            <div className="title">
+              <div>{name}</div>
+              <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
+            </div>
+            <span className="category">{category}</span>
+          </Container>
+          <StyledHr />
+        </>
+      ) : (
+        <Container>{children}</Container>
+      )}
     </>
   );
 };

--- a/src/components/document/DocsItem.jsx
+++ b/src/components/document/DocsItem.jsx
@@ -37,7 +37,8 @@ const StyledHr = styled.hr`
 const DocsItem = ({ name, category, isScraped, onClick, onScrapClick }) => {
   const [scrap, setScrap] = useState(isScraped);
 
-  const handleOnScrapFill = () => {
+  const handleOnScrapFill = (e) => {
+    e.stopPropagation();
     onScrapClick(!scrap);
     setScrap(!scrap);
   };
@@ -47,13 +48,7 @@ const DocsItem = ({ name, category, isScraped, onClick, onScrapClick }) => {
       <Container onClick={onClick}>
         <div className="title">
           <div>{name}</div>
-          <ScrapBtn
-            onClick={(e) => {
-              e.stopPropagation();
-              handleOnScrapFill();
-            }}
-            scrap={scrap}
-          />
+          <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
         </div>
         <span className="category">{category}</span>
       </Container>

--- a/src/components/document/DocsList.jsx
+++ b/src/components/document/DocsList.jsx
@@ -2,10 +2,9 @@ import { useState } from "react";
 import DocsItem from "./DocsItem";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import { useQuery, useMutation } from "@tanstack/react-query";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
-import { getUserInfo } from "@/services/mypage";
 import { useSelector } from "react-redux";
+import useDocsMutation from "@/hooks/useDocsMutation";
 
 const Container = styled.div`
   position: absolute;
@@ -20,30 +19,12 @@ const Container = styled.div`
 
 const DocsList = ({ data }) => {
   const navigate = useNavigate();
-
   const docsData = data?.pages.flatMap((x) => x.data.response.docsList) || [];
   const [scrapList, setScrapList] = useState([]);
-  const isLogin = useSelector((state) => state.user.isLogin);
+  const { memberId } = useSelector((state) => state.user);
 
-  const { data: memberId } = useQuery(["member_info"], getUserInfo, {
-    staleTime: Infinity,
-    select: (data) => data?.data?.response.id,
-    enabled: isLogin,
-  });
-
-  const { mutate: createScrap } = useMutation({
-    mutationFn: scrapCreate,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
-  const { mutate: deleteScrap } = useMutation({
-    mutationFn: scrapDelete,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
+  const { mutate: createScrap } = useDocsMutation(scrapCreate);
+  const { mutate: deleteScrap } = useDocsMutation(scrapDelete);
 
   const handleOnScrap = (el, scrap) => {
     const isSelected = scrapList.find((option) => option.id === el.docsId);

--- a/src/components/document/DocsList.jsx
+++ b/src/components/document/DocsList.jsx
@@ -9,12 +9,14 @@ import useDocsMutation from "@/hooks/useDocsMutation";
 const Container = styled.div`
   position: absolute;
   left: 15rem;
-  overflow-x: hidden;
   top: 6rem;
   padding: 2rem;
 
   background-color: white;
   box-shadow: 10px 0px 5px 0px rgba(0, 0, 0, 0.106);
+
+  overflow-y: auto;
+  max-height: calc(100vh - 6rem - 2 * 2rem);
 `;
 
 const DocsList = ({ data }) => {
@@ -49,20 +51,18 @@ const DocsList = ({ data }) => {
   };
 
   return (
-    <>
-      <Container>
-        {docsData.map((el) => (
-          <DocsItem
-            key={el.docsId}
-            name={el.docsName}
-            category={el.docsCategory}
-            onClick={() => handleOnClick(el.docsId)}
-            isScraped={el.scrap}
-            onScrapClick={(scrap) => handleOnScrap(el, scrap)}
-          />
-        ))}
-      </Container>
-    </>
+    <Container>
+      {docsData.map((el) => (
+        <DocsItem
+          key={el.docsId}
+          name={el.docsName}
+          category={el.docsCategory}
+          onClick={() => handleOnClick(el.docsId)}
+          isScraped={el.scrap}
+          onScrapClick={(scrap) => handleOnScrap(el, scrap)}
+        />
+      ))}
+    </Container>
   );
 };
 

--- a/src/components/document/DocsList.jsx
+++ b/src/components/document/DocsList.jsx
@@ -67,8 +67,9 @@ const DocsList = ({ data }) => {
   const handleOnClick = (el) => {
     if (isLogin) {
       navigate(`/document/${el}`);
+    } else {
+      return toast.warning("로그인 후 열람 가능합니다.");
     }
-    return toast.warning("로그인 후 열람 가능합니다.");
   };
 
   return (

--- a/src/components/document/DocsList.jsx
+++ b/src/components/document/DocsList.jsx
@@ -6,7 +6,6 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
 import { getUserInfo } from "@/services/mypage";
 import { useSelector } from "react-redux";
-import { toast, ToastContainer } from "react-toastify";
 
 const Container = styled.div`
   position: absolute;
@@ -65,26 +64,11 @@ const DocsList = ({ data }) => {
   };
 
   const handleOnClick = (el) => {
-    if (isLogin) {
-      navigate(`/document/${el}`);
-    } else {
-      return toast.warning("로그인 후 열람 가능합니다.");
-    }
+    navigate(`/document/${el}`);
   };
 
   return (
     <>
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="light"
-      />
       <Container>
         {docsData.map((el) => (
           <DocsItem

--- a/src/components/document/Document.jsx
+++ b/src/components/document/Document.jsx
@@ -16,7 +16,8 @@ import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import ScrapBtn from "./ScrapBtn";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
-import { getUserInfo } from "@/services/mypage";
+import { nullTokenEdit, successEdit, adminApproval } from "@/utils/toast";
+import { ToastContainer } from "react-toastify";
 
 const Group = styled.div`
   width: 22rem;
@@ -169,8 +170,11 @@ const Document = ({ data }) => {
   });
 
   const handleSetInput = () => {
-    setBasicEdit(true);
-    valueInit.docsName = docsName;
+    if (!isLogin) nullTokenEdit();
+    else {
+      setBasicEdit(true);
+      valueInit.docsName = docsName;
+    }
   };
 
   const handleAddressInfo = () => {
@@ -187,7 +191,7 @@ const Document = ({ data }) => {
       docsRequestLocation: addressInfo,
     });
 
-    toast.info("관리자 승인 후 갱신됩니다.");
+    adminApproval();
   };
 
   const handleBasicSave = () => {
@@ -205,13 +209,16 @@ const Document = ({ data }) => {
   };
 
   const handleInputContent = () => {
-    setEditContent(true);
-    setContentValue(docsContent);
+    if (!isLogin) nullTokenEdit();
+    else {
+      setEditContent(true);
+      setContentValue(docsContent);
+    }
   };
 
   const saveContentInfo = () => {
     mutationContentModify({ docs_id: id, docsContent: contentValue });
-    toast.success("내용이 수정되었습니다!");
+    successEdit();
   };
 
   const handleContentSave = () => {
@@ -242,17 +249,7 @@ const Document = ({ data }) => {
 
   return (
     <>
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="light"
-      />
+      <ToastContainer />
       <Container>
         {toggle && (
           <Group>

--- a/src/components/document/Document.jsx
+++ b/src/components/document/Document.jsx
@@ -6,18 +6,17 @@ import DocumentInput from "./DocumentInput";
 import ToggleBtn from "./ToggleBtn";
 import styled from "styled-components";
 import SelectMenu from "./SelectMenu";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { contentModify, basicModify } from "@/services/document";
 import { useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 import MDEditor from "@uiw/react-md-editor";
 import useInput from "@/hooks/useInput";
-import { toast, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import ScrapBtn from "./ScrapBtn";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
 import { nullTokenEdit, successEdit, adminApproval } from "@/utils/toast";
 import { ToastContainer } from "react-toastify";
+import useDocsMutation from "@/hooks/useDocsMutation";
 
 const Group = styled.div`
   width: 22rem;
@@ -96,14 +95,7 @@ const DocsInfo = styled.div`
 `;
 
 const Document = ({ data }) => {
-  const queryClient = useQueryClient();
-  const isLogin = useSelector((state) => state.user.isLogin);
-
-  const { data: memberId } = useQuery(["member_info"], getUserInfo, {
-    staleTime: Infinity,
-    enabled: isLogin,
-    select: (data) => data?.data?.response.id,
-  });
+  const { isLogin, memberId } = useSelector((state) => state.user);
 
   const {
     id,
@@ -135,39 +127,10 @@ const Document = ({ data }) => {
   const [scraped, setScrap] = useState(isScraped);
   const [toggle, setToggle] = useState(true);
 
-  const { mutate: mutationBasicModify } = useMutation({
-    mutationFn: basicModify,
-    onSuccess: () => {
-      queryClient.invalidateQueries("detail_document");
-    },
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
-  const { mutate: mutationContentModify } = useMutation({
-    mutationFn: contentModify,
-    onSuccess: () => {
-      queryClient.invalidateQueries("detail_document");
-    },
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
-  const { mutate: scrapDetailCreate } = useMutation({
-    mutationFn: scrapCreate,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
-  const { mutate: scrapDetailDelete } = useMutation({
-    mutationFn: scrapDelete,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
+  const { mutate: mutationBasicModify } = useDocsMutation(basicModify);
+  const { mutate: mutationContentModify } = useDocsMutation(contentModify);
+  const { mutate: scrapDetailCreate } = useDocsMutation(scrapCreate);
+  const { mutate: scrapDetailDelete } = useDocsMutation(scrapDelete);
 
   const handleSetInput = () => {
     if (!isLogin) nullTokenEdit();

--- a/src/components/document/Document.jsx
+++ b/src/components/document/Document.jsx
@@ -30,19 +30,7 @@ const Group = styled.div`
   background-color: white;
   box-shadow: 10px 0px 5px 0px rgba(0, 0, 0, 0.106);
   box-sizing: border-box;
-  overflow: scroll;
-  overflow-x: hidden;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    border-radius: 6px;
-    background: rgba(237, 214, 214, 0.4);
-  }
-  &::-webkit-scrollbar-thumb {
-    background: rgba(86, 77, 77, 0.3);
-    border-radius: 6px;
-  }
+  overflow: auto;
 
   #docsName,
   #docsLocation,

--- a/src/components/mypage/MypageScrap.jsx
+++ b/src/components/mypage/MypageScrap.jsx
@@ -5,14 +5,11 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { mypagescrap } from "@/services/mypage";
 import Loader from "@/components/common/layout/Loader";
 import { Suspense } from "react";
-import { useSelector } from "react-redux";
 import { useState } from "react";
 import MainLayout from "../common/layout/MainLayout";
 import DocumentWrapper from "../document/DocumentWrapper";
-import DocsList from "../document/DocsList";
 
 const MypageScrap = () => {
-  /** 무한스크롤 */
   const [show, setShow] = useState(true);
 
   const handleShow = () => {
@@ -65,7 +62,7 @@ const MypageScrap = () => {
 
   return (
     <>
-      <MainLayout myActive={true} onClick={handleShow} />
+      <MainLayout myPageClicked={true} onClick={handleShow} />
       {show && (
         <DocumentWrapper>
           <Suspense fallback={<Loader />}>

--- a/src/components/mypage/MypageScrap.jsx
+++ b/src/components/mypage/MypageScrap.jsx
@@ -13,7 +13,7 @@ const MypageScrap = () => {
   const [show, setShow] = useState(true);
 
   const handleShow = () => {
-    setShow(!show);
+    setShow((prev) => !prev);
   };
 
   const bottomObserver = useRef(null);
@@ -56,17 +56,13 @@ const MypageScrap = () => {
     };
   }, [isLoading, hasNextPage, fetchNextPage]);
 
-  const title = data?.pages
-    .flatMap((x) => x?.data?.response.scrapList)
-    .map((x) => x?.docsName);
-
   return (
     <>
       <MainLayout myPageClicked={true} onClick={handleShow} />
       {show && (
         <DocumentWrapper>
           <Suspense fallback={<Loader />}>
-            {title?.length && <ScrapList datas={data} />}
+            <ScrapList datas={data} />
             <div style={{ height: "50px" }} ref={bottomObserver}></div>
           </Suspense>
         </DocumentWrapper>

--- a/src/components/mypage/ScrapList.jsx
+++ b/src/components/mypage/ScrapList.jsx
@@ -1,14 +1,11 @@
 import styled from "styled-components";
-import ScrapBtn from "@/components/document/ScrapBtn";
 import DocsItem from "@/components/document/DocsItem";
 import { useNavigate } from "react-router-dom";
-import routes from "@/routes";
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
-import ScrapDocs from "./ScrapDocs";
-import { getUserInfo } from "@/services/mypage";
-import { useQuery } from "@tanstack/react-query";
+import useDocsMutation from "@/hooks/useDocsMutation";
+import { useSelector } from "react-redux";
+
 const Container = styled.div`
   position: absolute;
   left: 15rem;
@@ -24,26 +21,10 @@ const ScrapList = ({ datas }) => {
 
   const docsData = datas?.pages.flatMap((x) => x.data.response.scrapList) || [];
   const [scrapList, setScrapList] = useState([]);
-  const token = localStorage.getItem("token");
+  const { memberId } = useSelector((state) => state.user);
 
-  const { data: memberId } = useQuery(["member_scrap"], getUserInfo, {
-    staleTime: Infinity,
-    select: (data) => data?.data?.response.id,
-    enabled: !!token,
-  });
-  const { mutate: createScrap } = useMutation({
-    mutationFn: scrapCreate,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
-
-  const { mutate: deleteScrap } = useMutation({
-    mutationFn: scrapDelete,
-    onError: (error) => {
-      console.error(error);
-    },
-  });
+  const { mutate: createScrap } = useDocsMutation(scrapCreate);
+  const { mutate: deleteScrap } = useDocsMutation(scrapDelete);
 
   const handleOnScrap = (el, scrap) => {
     const isSelected = scrapList.find((option) => option.id === el.docsId);

--- a/src/components/mypage/ScrapList.jsx
+++ b/src/components/mypage/ScrapList.jsx
@@ -10,12 +10,14 @@ import { HELPER_MSG } from "@/constant/helpermsg";
 const Container = styled.div`
   position: absolute;
   left: 15rem;
-  overflow-x: hidden;
   top: 6rem;
   padding: 2rem;
 
   background-color: white;
   box-shadow: 10px 0px 5px 0px rgba(0, 0, 0, 0.106);
+
+  overflow-y: auto;
+  max-height: calc(100vh - 6rem - 2 * 2rem);
 `;
 const ScrapList = ({ datas }) => {
   const navigate = useNavigate();

--- a/src/components/mypage/ScrapList.jsx
+++ b/src/components/mypage/ScrapList.jsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
 import useDocsMutation from "@/hooks/useDocsMutation";
 import { useSelector } from "react-redux";
+import { HELPER_MSG } from "@/constant/helpermsg";
 
 const Container = styled.div`
   position: absolute;
@@ -43,19 +44,22 @@ const ScrapList = ({ datas }) => {
       deleteScrap({ memberId, docsId: el.docsId });
     }
   };
-
   return (
     <Container>
-      {docsData.map((el) => (
-        <DocsItem
-          key={el.docsId}
-          name={el.docsName}
-          category={el.docsCategory}
-          onClick={() => navigate(`/document/${el.docsId}`)}
-          isScraped={true}
-          onScrapClick={(scrap) => handleOnScrap(el, scrap)}
-        />
-      ))}
+      {docsData.length ? (
+        docsData.map((el) => (
+          <DocsItem
+            key={el.docsId}
+            name={el.docsName}
+            category={el.docsCategory}
+            onClick={() => navigate(`/document/${el.docsId}`)}
+            isScraped={true}
+            onScrapClick={(scrap) => handleOnScrap(el, scrap)}
+          />
+        ))
+      ) : (
+        <DocsItem>{HELPER_MSG.NO_SCRAP}</DocsItem>
+      )}
     </Container>
   );
 };

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -7,7 +7,7 @@ import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
 import SearchItem from "./SearchItem";
 import { useSelector } from "react-redux";
-import { toast, ToastContainer } from "react-toastify";
+import { ToastContainer } from "react-toastify";
 
 const StyledSearchBar = styled.input`
   width: 40rem;
@@ -108,52 +108,41 @@ const SearchBar = () => {
 
   return (
     <>
-      <ToastContainer
-        position="top-right"
-        autoClose={3000}
-        hideProgressBar={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme="light"
+      <ToastContainer />
+
+      <StyledSearchBar
+        type="search"
+        placeholder="      검색"
+        ref={focusRef}
+        onFocus={onFocusSearchBar}
+        onBlur={onBlurSearchBar}
+        value={inputValue}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          debouncedSearchDocs(e.target.value);
+          throttledSearchDocs(e.target.value);
+        }}
       />
-      <div>
-        <StyledSearchBar
-          type="search"
-          placeholder="      검색"
-          ref={focusRef}
-          onFocus={onFocusSearchBar}
-          onBlur={onBlurSearchBar}
-          value={inputValue}
-          onChange={(e) => {
-            setInputValue(e.target.value);
-            debouncedSearchDocs(e.target.value);
-            throttledSearchDocs(e.target.value);
-          }}
-        />
-        {isSuccess
-          ? clickedSearch &&
-            inputValue && (
-              <Container ref={searchRef}>
-                {searchResults &&
-                  searchResults
-                    .slice(0, 8)
-                    .map((el) => (
-                      <SearchItem
-                        key={el.docsId}
-                        name={el.docsName}
-                        onClick={() => handleOnClick(el.docsId)}
-                      />
-                    ))}
-              </Container>
-            )
-          : clickedSearch &&
-            inputValue && (
-              <Container ref={searchRef}>검색 결과가 없습니다. 🥲</Container>
-            )}
-      </div>
+      {isSuccess
+        ? clickedSearch &&
+          inputValue && (
+            <Container ref={searchRef}>
+              {searchResults &&
+                searchResults
+                  .slice(0, 8)
+                  .map((el) => (
+                    <SearchItem
+                      key={el.docsId}
+                      name={el.docsName}
+                      onClick={() => handleOnClick(el.docsId)}
+                    />
+                  ))}
+            </Container>
+          )
+        : clickedSearch &&
+          inputValue && (
+            <Container ref={searchRef}>검색 결과가 없습니다. 🥲</Container>
+          )}
     </>
   );
 };

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -3,10 +3,11 @@ import { useState, useRef, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { searchDocs } from "@/services/document";
 import { useNavigate } from "react-router-dom";
-import routes from "@/routes";
 import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
 import SearchItem from "./SearchItem";
+import { useSelector } from "react-redux";
+import { toast, ToastContainer } from "react-toastify";
 
 const StyledSearchBar = styled.input`
   width: 40rem;
@@ -50,8 +51,9 @@ const SearchBar = () => {
   const [clickedSearch, setClickedSearch] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [searchResults, setSearchResults] = useState([]);
-  const [selectedDocs, setSelectedDocs] = useState([]);
+
   const navigate = useNavigate();
+  const isLogin = useSelector((state) => state.user.isLogin);
 
   useEffect(() => {
     const handleOnClickedSearch = (e) => {
@@ -96,56 +98,63 @@ const SearchBar = () => {
   );
 
   const handleOnClick = (el) => {
-    setSelectedDocs((prev) => [
-      ...prev,
-      {
-        id: el.docsId,
-        docsLocation: {
-          lat: el.docsLocation.lat,
-          lng: el.docsLocation.lng,
-        },
-      },
-    ]);
-    selectedDocs.length > 0 &&
-      navigate(routes.documentPage, { state: selectedDocs[0] });
+    if (isLogin) {
+      navigate(`/document/${el}`);
+      setClickedSearch(false);
+    } else {
+      return toast.warning("로그인 후 열람 가능합니다.");
+    }
   };
 
   return (
-    <div>
-      <StyledSearchBar
-        type="search"
-        placeholder="      검색"
-        ref={focusRef}
-        onFocus={onFocusSearchBar}
-        onBlur={onBlurSearchBar}
-        value={inputValue}
-        onChange={(e) => {
-          setInputValue(e.target.value);
-          debouncedSearchDocs(e.target.value);
-          throttledSearchDocs(e.target.value);
-        }}
+    <>
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
       />
-      {isSuccess
-        ? clickedSearch &&
-          inputValue && (
-            <Container ref={searchRef}>
-              {searchResults &&
-                searchResults
-                  .slice(0, 8)
-                  .map((el) => (
-                    <SearchItem
-                      key={el.docsId}
-                      name={el.docsName}
-                      onClick={() => handleOnClick(el)}
-                    />
-                  ))}
-            </Container>
-          )
-        : clickedSearch &&
-          inputValue && (
-            <Container ref={searchRef}>검색 결과가 없습니다. 🥲</Container>
-          )}
-    </div>
+      <div>
+        <StyledSearchBar
+          type="search"
+          placeholder="      검색"
+          ref={focusRef}
+          onFocus={onFocusSearchBar}
+          onBlur={onBlurSearchBar}
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            debouncedSearchDocs(e.target.value);
+            throttledSearchDocs(e.target.value);
+          }}
+        />
+        {isSuccess
+          ? clickedSearch &&
+            inputValue && (
+              <Container ref={searchRef}>
+                {searchResults &&
+                  searchResults
+                    .slice(0, 8)
+                    .map((el) => (
+                      <SearchItem
+                        key={el.docsId}
+                        name={el.docsName}
+                        onClick={() => handleOnClick(el.docsId)}
+                      />
+                    ))}
+              </Container>
+            )
+          : clickedSearch &&
+            inputValue && (
+              <Container ref={searchRef}>검색 결과가 없습니다. 🥲</Container>
+            )}
+      </div>
+    </>
   );
 };
 

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -6,8 +6,8 @@ import { useNavigate } from "react-router-dom";
 import debounce from "lodash/debounce";
 import throttle from "lodash/throttle";
 import SearchItem from "./SearchItem";
-import { useSelector } from "react-redux";
 import { ToastContainer } from "react-toastify";
+import { HELPER_MSG } from "@/constant/helpermsg";
 
 const StyledSearchBar = styled.input`
   width: 40rem;
@@ -48,12 +48,10 @@ const Container = styled.div`
 const SearchBar = () => {
   const focusRef = useRef(null);
   const searchRef = useRef(null);
+  const navigate = useNavigate();
   const [clickedSearch, setClickedSearch] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [searchResults, setSearchResults] = useState([]);
-
-  const navigate = useNavigate();
-  const isLogin = useSelector((state) => state.user.isLogin);
 
   useEffect(() => {
     const handleOnClickedSearch = (e) => {
@@ -105,40 +103,41 @@ const SearchBar = () => {
   return (
     <>
       <ToastContainer />
-
-      <StyledSearchBar
-        type="search"
-        placeholder="      검색"
-        ref={focusRef}
-        onFocus={onFocusSearchBar}
-        onBlur={onBlurSearchBar}
-        value={inputValue}
-        onChange={(e) => {
-          setInputValue(e.target.value);
-          debouncedSearchDocs(e.target.value);
-          throttledSearchDocs(e.target.value);
-        }}
-      />
-      {isSuccess
-        ? clickedSearch &&
-          inputValue && (
-            <Container ref={searchRef}>
-              {searchResults &&
-                searchResults
-                  .slice(0, 8)
-                  .map((el) => (
-                    <SearchItem
-                      key={el.docsId}
-                      name={el.docsName}
-                      onClick={() => handleOnClick(el.docsId)}
-                    />
-                  ))}
-            </Container>
-          )
-        : clickedSearch &&
-          inputValue && (
-            <Container ref={searchRef}>검색 결과가 없습니다. 🥲</Container>
-          )}
+      <div>
+        <StyledSearchBar
+          type="search"
+          placeholder="      검색"
+          ref={focusRef}
+          onFocus={onFocusSearchBar}
+          onBlur={onBlurSearchBar}
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            debouncedSearchDocs(e.target.value);
+            throttledSearchDocs(e.target.value);
+          }}
+        />
+        {isSuccess
+          ? clickedSearch &&
+            inputValue && (
+              <Container ref={searchRef}>
+                {searchResults &&
+                  searchResults
+                    .slice(0, 8)
+                    .map((el) => (
+                      <SearchItem
+                        key={el.docsId}
+                        name={el.docsName}
+                        onClick={() => handleOnClick(el.docsId)}
+                      />
+                    ))}
+              </Container>
+            )
+          : clickedSearch &&
+            inputValue && (
+              <Container ref={searchRef}>{HELPER_MSG.NO_SEARCH}</Container>
+            )}
+      </div>
     </>
   );
 };

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -98,12 +98,8 @@ const SearchBar = () => {
   );
 
   const handleOnClick = (el) => {
-    if (isLogin) {
-      navigate(`/document/${el}`);
-      setClickedSearch(false);
-    } else {
-      return toast.warning("로그인 후 열람 가능합니다.");
-    }
+    navigate(`/document/${el}`);
+    setClickedSearch(false);
   };
 
   return (

--- a/src/constant/helpermsg.js
+++ b/src/constant/helpermsg.js
@@ -1,4 +1,5 @@
-export const helperMsg = {
-  title: "시설의 명칭을 정확하게 기입해주세요.",
-  location: "지도에서 건물의 위치를 클릭하세요.",
+export const HELPER_MSG = {
+  TITLE: "시설의 명칭을 정확하게 기입해주세요.",
+  LOCATION: "지도에서 건물의 위치를 클릭하세요.",
+  NO_SCRAP: "스크랩한 내역이 없습니다.",
 };

--- a/src/constant/helpermsg.js
+++ b/src/constant/helpermsg.js
@@ -1,6 +1,12 @@
 export const HELPER_MSG = {
-  TITLE: "시설의 명칭을 정확하게 기입해주세요.",
+  NAME: "시설의 명칭을 정확하게 기입해주세요.",
   LOCATION: "지도에서 건물의 위치를 클릭하세요.",
   NO_SCRAP: "스크랩한 내역이 없습니다.",
   NO_SEARCH: "검색 결과가 없습니다.",
+};
+
+export const ERROR_MSG = {
+  NAME: "문서 제목을 입력해주세요.",
+  LOCATION: "등록하려는 장소의 위치를 지도에서 클릭해주세요.",
+  CATEGORY: " 카테고리를 선택해주세요.",
 };

--- a/src/constant/helpermsg.js
+++ b/src/constant/helpermsg.js
@@ -1,4 +1,4 @@
 export const helperMsg = {
   title: "시설의 명칭을 정확하게 기입해주세요.",
-  location: "건물의 해당 위치를 지도에서 클릭하세요.",
+  location: "지도에서 건물의 위치를 클릭하세요.",
 };

--- a/src/constant/helpermsg.js
+++ b/src/constant/helpermsg.js
@@ -2,4 +2,5 @@ export const HELPER_MSG = {
   TITLE: "시설의 명칭을 정확하게 기입해주세요.",
   LOCATION: "지도에서 건물의 위치를 클릭하세요.",
   NO_SCRAP: "스크랩한 내역이 없습니다.",
+  NO_SEARCH: "검색 결과가 없습니다.",
 };

--- a/src/hooks/useDocsMutation.js
+++ b/src/hooks/useDocsMutation.js
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useDocsMutation = (mutationFn) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, ...rest } = useMutation({
+    mutationFn,
+    onSuccess: () => {
+      queryClient.invalidateQueries("detail_document");
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+
+  return { mutate, ...rest };
+};
+
+export default useDocsMutation;

--- a/src/hooks/useValidation.js
+++ b/src/hooks/useValidation.js
@@ -1,20 +1,17 @@
 import { useState } from "react";
+import { ERROR_MSG } from "@/constant/helpermsg";
 
 const useValidation = (initialValue) => {
   const [msg, setMsg] = useState(initialValue);
 
   const docsNameCheck = (docsName) => {
-    return docsName === "" ? "문서 제목을 입력해주세요." : "";
+    return docsName === "" && ERROR_MSG.NAME;
   };
   const docsLocation = (docsLocation) => {
-    return docsLocation === "" ||
-      docsLocation.lat === undefined ||
-      docsLocation.lng === undefined
-      ? "위치를 지도에서 클릭해주세요"
-      : "";
+    return !docsLocation.lat && ERROR_MSG.LOCATION;
   };
   const docsCategory = (docsCategory) => {
-    return docsCategory === "" ? "카테고리를 입력해주세요." : "";
+    return docsCategory === "" && ERROR_MSG.CATEGORY;
   };
 
   const handleSetMsg = (id, value) => {

--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,18 @@ section {
 
 body {
   line-height: 1;
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    border-radius: 6px;
+    background: rgba(237, 214, 214, 0.4);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: rgba(86, 77, 77, 0.3);
+    border-radius: 6px;
+  }
 }
 
 ol,

--- a/src/pages/AddPost.jsx
+++ b/src/pages/AddPost.jsx
@@ -14,11 +14,11 @@ const AddPost = () => {
   return (
     <>
       <MainLayout onClick={handleShow} />
-      {show ? (
+      {show && (
         <DocumentWrapper>
           <CreateDocument />
         </DocumentWrapper>
-      ) : undefined}
+      )}
       <Map />
     </>
   );

--- a/src/pages/DocumentListPage.jsx
+++ b/src/pages/DocumentListPage.jsx
@@ -12,7 +12,7 @@ const DocumentListPage = () => {
   const [show, setShow] = useState(true);
 
   const handleShow = () => {
-    setShow(!show);
+    setShow((prev) => !prev);
   };
 
   const bottomObserver = useRef(null);

--- a/src/pages/DocumentListPage.jsx
+++ b/src/pages/DocumentListPage.jsx
@@ -34,6 +34,7 @@ const DocumentListPage = () => {
             ? nextPage
             : undefined;
         },
+        refetchOnWindowFocus: true,
       }
     );
 

--- a/src/pages/DocumentPage.jsx
+++ b/src/pages/DocumentPage.jsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 const DocumentPage = () => {
   const { id } = useParams();
   const { data } = useQuery(["detail_document", id], () => detailDocument(id), {
+    refetchOnWindowFocus: true,
     select: (data) => data?.data?.response,
   });
 

--- a/src/pages/DocumentPage.jsx
+++ b/src/pages/DocumentPage.jsx
@@ -13,7 +13,7 @@ const DocumentPage = () => {
 
   return (
     <>
-      <MainLayout viewActive={true}>
+      <MainLayout isActive={true}>
         <Document data={data} />
       </MainLayout>
       {data && (

--- a/src/pages/MyInfoEdit.jsx
+++ b/src/pages/MyInfoEdit.jsx
@@ -3,7 +3,7 @@ import MainLayout from "@/components/common/layout/MainLayout.jsx";
 
 const MyInfoEdit = () => {
   return (
-    <MainLayout>
+    <MainLayout myPageClicked={true}>
       <MyInfoEditForm />
     </MainLayout>
   );

--- a/src/pages/MyInfoEdit.jsx
+++ b/src/pages/MyInfoEdit.jsx
@@ -3,11 +3,9 @@ import MainLayout from "@/components/common/layout/MainLayout.jsx";
 
 const MyInfoEdit = () => {
   return (
-    <div>
-      <MainLayout myActive={true}>
-        <MyInfoEditForm />
-      </MainLayout>
-    </div>
+    <MainLayout>
+      <MyInfoEditForm />
+    </MainLayout>
   );
 };
 

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -7,7 +7,7 @@ const MyPage = () => {
   const user = useSelector((state) => state.user);
   return (
     <>
-      <MainLayout myActive={true}>
+      <MainLayout myPageClicked={true}>
         {localStorage.getItem("token") && user.isLogin ? (
           <MypageForm></MypageForm>
         ) : (

--- a/src/pages/Scrap.jsx
+++ b/src/pages/Scrap.jsx
@@ -9,7 +9,7 @@ const Scrap = () => {
 
   return (
     <>
-      <MainLayout myActive={true} scrapActive={true}>
+      <MainLayout myPageClicked={true}>
         {user.isLogin ? (
           <MypageScrap />
         ) : (

--- a/src/styles/globalStyle.jsx
+++ b/src/styles/globalStyle.jsx
@@ -4,16 +4,5 @@ export const GlobalStyle = createGlobalStyle`
    html, body{
     width: 100vw;
     font-family: var(--font-pretendard-light);
-
-   &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-    border-radius: 6px;
-    background: rgba(237, 214, 214, 0.4);
-  }
-    &::-webkit-scrollbar-thumb {
-        background: rgba(86, 77, 77, 0.3);
-        border-radius: 6px;
-    }
  }
 `;

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -8,7 +8,7 @@ const swalWithBootstrapButtons = Swal.mixin({
   buttonsStyling: true,
 });
 
-export const askAlert = ({ name, address, category }) => {
+export const askAlert = (name, address, category) => {
   return swalWithBootstrapButtons.fire({
     title: "문서를 등록하시겠습니까?",
     html: `문서제목: ${name}<br/>

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -1,0 +1,39 @@
+import Swal from "sweetalert2";
+
+const swalWithBootstrapButtons = Swal.mixin({
+  customClass: {
+    confirmButton: "btn btn-success",
+    cancelButton: "btn btn-danger",
+  },
+  buttonsStyling: true,
+});
+
+export const askAlert = ({ name, address, category }) => {
+  return swalWithBootstrapButtons.fire({
+    title: "문서를 등록하시겠습니까?",
+    html: `문서제목: ${name}<br/>
+      위치: ${address}<br/>
+      카테고리: ${category}`,
+    icon: "warning",
+    showCancelButton: true,
+    confirmButtonText: "등록 요청",
+    cancelButtonText: "취소",
+    reverseButtons: true,
+  });
+};
+
+export const cancelAlert = () => {
+  return swalWithBootstrapButtons.fire(
+    "취소 완료",
+    "문서 등록 요청을 취소합니다.",
+    "error"
+  );
+};
+
+export const requestAlert = () => {
+  return swalWithBootstrapButtons.fire(
+    "문서 등록 요청 완료!",
+    "관리자의 승인 후 등록이 완료됩니다.",
+    "success"
+  );
+};

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -37,3 +37,15 @@ export const requestAlert = () => {
     "success"
   );
 };
+
+export const popUpLogout = () => {
+  return Swal.fire({
+    icon: "question",
+    text: "로그아웃 하시겠습니까?",
+    showCancelButton: true,
+    confirmButtonText: "예",
+    cancelButtonText: "아니오",
+    confirmButtonColor: "#429f50",
+    cancelButtonColor: "#d33",
+  });
+};

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,0 +1,37 @@
+import { toast } from "react-toastify";
+
+export const nullTokenWrite = () => {
+  return toast.warning("로그인 후 작성 가능합니다.", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};
+
+export const nullTokenEdit = () => {
+  return toast.warning("로그인 후 편집 가능합니다.", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};
+
+export const occurError = () => {
+  return toast.error("문서 생성에 실패했습니다. 관리자에게 문의하세요.", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};
+
+export const successEdit = () => {
+  return toast.success("내용이 수정되었습니다!", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};
+
+export const adminApproval = () => {
+  return toast.info("관리자 승인 후 갱신됩니다.", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};
+
+export const nullTokenOpen = () => {
+  return toast.warning("로그인 후 열람 가능합니다.", {
+    position: toast.POSITION.TOP_RIGHT,
+  });
+};


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

- useMutation 관련 로직 커스텀훅으로 분리(src/hooks/useDocsMutation)
- 마이페이지-스크랩에서 스크랩 해제 시 바로바로 반영
- 스크롤바 위치 변경(문서목록, 스크랩목록)
- alert/toast 관련 로직 함수로 분리(src/utils/alert, toast)
- 사이드바 관련로직 변경
  - 리덕스 사용 하지않고 prop으로 변경 (리덕스 관련 파일 안쓸것 같으면 지워도 될듯합니다!)
  - 마이페이지의 화살표만 눌렀을 때 마이페이지로 이동X
  - 마이페이지에 접속하지 않고 화살표만 눌렀을 때 배경색 X
 - 문서 열람은 로그인하지 않아도 열람 가능
 - memberId 부분은 react-query 사용하지 않고 useSelector로 호출