### PR TITLE
로그인, 회원가입 및 헤더에 시맨틱 태그 적용

### DIFF
--- a/src/components/admin/RequestContain.jsx
+++ b/src/components/admin/RequestContain.jsx
@@ -1,18 +1,9 @@
 import styled from "styled-components";
 import Request from "./Request";
-import Title from "@/components/register/Title";
-import Loader from "@/components/common/layout/Loader";
+import Title from "@/components/common/Title";
 import { useEffect, useState } from "react";
 
-const RequestContain = ({
-  error,
-  isLoading,
-  border,
-  datas,
-  route,
-  modi,
-  children,
-}) => {
+const RequestContain = ({ error, border, datas, route, modi, children }) => {
   const [errorState, setErrorState] = useState(false);
   useEffect(() => {
     error?.data.error?.status == 404
@@ -49,11 +40,8 @@ const RequestContain = ({
           })}
         </>
       )}
-      {/* {isLoading ? <Loader /> : <></>} */}
 
       {children}
-
-      {/* Title 추후 위치 수정 */}
     </RequestContainCss>
   );
 };

--- a/src/components/common/Subtitle.jsx
+++ b/src/components/common/Subtitle.jsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+const Subtitle = ({ children, fontSize, margin }) => {
+  return (
+    <SubtitleStyle fontSize={fontSize} margin={margin}>
+      {children}
+    </SubtitleStyle>
+  );
+};
+
+const SubtitleStyle = styled.span`
+  color: #216d32;
+  font-size: ${(props) => props.fontSize};
+  margin: ${(props) => props.margin};
+`;
+
+export default Subtitle;

--- a/src/components/common/Title.jsx
+++ b/src/components/common/Title.jsx
@@ -8,11 +8,10 @@ const Title = ({ children, fontSize, margin }) => {
   );
 };
 
-const TitleStyle = styled.p`
+const TitleStyle = styled.h3`
   color: #216d32;
   font-size: ${(props) => props.fontSize};
   margin: ${(props) => props.margin};
-  /* margin-bottom: 4rem; */
 `;
 
 export default Title;

--- a/src/components/common/form/AdminForm.jsx
+++ b/src/components/common/form/AdminForm.jsx
@@ -1,4 +1,4 @@
-import Title from "@/components/register/Title";
+import Title from "@/components/common/Title";
 import Contain from "@/components/admin/Contain";
 import AdminBox from "@/components/admin/AdminBox";
 

--- a/src/components/common/form/LoginForm.jsx
+++ b/src/components/common/form/LoginForm.jsx
@@ -4,7 +4,7 @@ import Button from "@/components/register/Button";
 import routes from "@/routes";
 import { useNavigate } from "react-router-dom";
 import Question from "@/components/register/Question";
-import Title from "@/components/register/Title";
+import Title from "../Title";
 import { login } from "@/services/user";
 import { useDispatch } from "react-redux";
 import { loginState } from "@/store/userReducer";
@@ -12,6 +12,7 @@ import { loginFailAlert } from "@/utils/alert";
 import { useForm } from "react-hook-form";
 import { emailRule, passwordRule } from "@/utils/registerRules";
 import { useMutation } from "@tanstack/react-query";
+import Subtitle from "../Subtitle";
 
 const LoginForm = () => {
   const dispatch = useDispatch();
@@ -45,7 +46,6 @@ const LoginForm = () => {
       })
     );
     navigate(routes.home);
-    location.reload();
   };
 
   const goLogin = (email, password) => {
@@ -77,10 +77,9 @@ const LoginForm = () => {
       <Title fontSize="30px" margin="0 0 1rem 0">
         로그인
       </Title>
-      <Title fontSize="15px" margin="0 0 2rem 0">
-        {" "}
+      <Subtitle fontSize="15px" margin="0 0 2rem 0">
         환영해요! 오늘도 전남대 정보들, 잘 부탁해요 :)
-      </Title>
+      </Subtitle>
       <InputGroup
         id="email"
         placeholder="전남대학교 이메일을 입력해주세요."

--- a/src/components/common/form/MyInfoEditForm.jsx
+++ b/src/components/common/form/MyInfoEditForm.jsx
@@ -1,6 +1,6 @@
 import InputGroup from "@/components/common/Input/InputGroup";
 import Container from "@/components/register/Container";
-import Title from "@/components/register/Title";
+import Title from "@/components/common/Title";
 import { useState } from "react";
 import { getChangeNickname, getChangePassword } from "@/services/mypage";
 import routes from "@/routes";

--- a/src/components/common/form/MypageForm.jsx
+++ b/src/components/common/form/MypageForm.jsx
@@ -1,6 +1,6 @@
 import MyInputGroup from "@/components/mypage/MyInfoGroup";
 import Container from "@/components/register/Container";
-import Title from "@/components/register/Title";
+import Title from "@/components/common/Title";
 import styled from "styled-components";
 import MyBtn from "@/components/mypage/MyBtn";
 import { getUserInfo } from "@/services/mypage";

--- a/src/components/common/form/RegisterForm.jsx
+++ b/src/components/common/form/RegisterForm.jsx
@@ -6,7 +6,7 @@ import routes from "@/routes";
 import { useNavigate } from "react-router-dom";
 import Question from "@/components/register/Question";
 import { useState } from "react";
-import Title from "@/components/register/Title";
+import Title from "../Title";
 import { useForm } from "react-hook-form";
 import { useMutation } from "@tanstack/react-query";
 import {
@@ -21,6 +21,7 @@ import { joinSuccessAlert } from "@/utils/alert";
 import { JOIN_DOUBLE_CHECK } from "@/constant/document/auth";
 import { joinFailAlert } from "@/utils/alert";
 import { NameDoubleCheck, emailDoubleCheck } from "../user/DoubleCheck";
+import Subtitle from "../Subtitle";
 const { DOUBLED } = JOIN_DOUBLE_CHECK;
 
 const RegisterForm = () => {
@@ -69,14 +70,19 @@ const RegisterForm = () => {
   };
 
   return (
-    <Container onSubmit={handleSubmit(onSubmit)}>
+    <Container
+      onSubmit={() => {
+        console.log("폼 제출");
+        handleSubmit(onSubmit);
+      }}
+    >
       <Title fontSize="30px" margin="0 0 1rem 0">
         회원가입
       </Title>
 
-      <Title fontSize="15px" margin="0 0 2rem 0">
+      <Subtitle fontSize="15px" margin="0 0 2rem 0">
         반가워요! 전남대학교에 대한 정보를 공유해봐요 :)
-      </Title>
+      </Subtitle>
 
       <InputGroup
         id="email"

--- a/src/components/common/layout/Sidebar.jsx
+++ b/src/components/common/layout/Sidebar.jsx
@@ -46,7 +46,7 @@ function Sidebar({ isActive, myPageClicked, onClick, isMenu }) {
   );
 }
 
-const Container = styled.aside`
+const Container = styled.nav`
   width: 15rem;
   height: 100vh;
 

--- a/src/components/common/layout/Sidebar.jsx
+++ b/src/components/common/layout/Sidebar.jsx
@@ -46,7 +46,7 @@ function Sidebar({ isActive, myPageClicked, onClick, isMenu }) {
   );
 }
 
-const Container = styled.div`
+const Container = styled.aside`
   width: 15rem;
   height: 100vh;
 

--- a/src/components/mypage/MyInfo.jsx
+++ b/src/components/mypage/MyInfo.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const MyInfo = ({ children }) => {
   return <MyInfoField>{children}</MyInfoField>;
 };
-const MyInfoField = styled.div`
+const MyInfoField = styled.section`
   font-size: 14px;
   font-weight: 300;
 `;

--- a/src/components/mypage/MypageStyle.js
+++ b/src/components/mypage/MypageStyle.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const Container = styled.div`
+export const Container = styled.section`
   position: absolute;
   left: 15rem;
   overflow-x: hidden;
@@ -14,7 +14,7 @@ export const Container = styled.div`
   height: 80%;
 `;
 
-export const Title = styled.div`
+export const Title = styled.h1`
   padding-left: 1rem;
   padding-right: 1rem;
   display: flex;

--- a/src/components/register/Box.jsx
+++ b/src/components/register/Box.jsx
@@ -1,12 +1,14 @@
 import styled from "styled-components";
 
+const Box = ({ children, bottom }) => {
+  return <BoxCss bottom={bottom}>{children}</BoxCss>;
+};
+
 const BoxCss = styled.div`
   background-color: #ffffff;
 
   width: 423px;
-
-  display: flex;
-  flex-direction: column;
+  margin-top: 1.2rem;
 
   position: relative;
   bottom: ${(props) => (props ? "0" : "2rem")};
@@ -15,9 +17,5 @@ const BoxCss = styled.div`
     width: 21rem;
   }
 `;
-
-const Box = ({ children, bottom }) => {
-  return <BoxCss bottom={bottom}>{children}</BoxCss>;
-};
 
 export default Box;

--- a/src/components/register/Question.jsx
+++ b/src/components/register/Question.jsx
@@ -9,7 +9,7 @@ const Question = ({ para, children, onClick }) => {
   );
 };
 
-const QuestionStyle = styled.div`
+const QuestionStyle = styled.p`
   display: flex;
 
   color: #7d7d7d;
@@ -19,7 +19,7 @@ const QuestionStyle = styled.div`
     margin-bottom: 5rem;
   }
 `;
-const QuestionBtnStyle = styled.div`
+const QuestionBtnStyle = styled.p`
   color: #216d32;
   font-size: 15px;
   margin-left: 1rem;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

- 로그인, 회원가입, 마이페이지, 어드민 페이지에서 사용되는 Title의 위치 수정(register->common) 
- Title , Subtitle 분리
- Sidebar, 마이페이지, 로그인, 회원가입 페이지 시맨틱 태그 적용

## 관련 이슈

- closes
