### PR TITLE
refactor: 문서 상세 조회 리팩토링

### DIFF
--- a/src/components/Map/MapWithClickEvent.jsx
+++ b/src/components/Map/MapWithClickEvent.jsx
@@ -35,7 +35,6 @@ const MapWithClickEvent = ({ location }) => {
     const roadAddress = result[0].road_address
       ? "도로명주소: " + result[0].road_address.address_name
       : "";
-
     const streetAddress = "지번주소: " + result[0].address.address_name;
 
     const payloadAddress = result[0].road_address
@@ -69,11 +68,11 @@ const MapWithClickEvent = ({ location }) => {
     };
 
     searchDetailAddrFromCoords(coord, callback);
-  }, []);
+  }, [location, dispatch, isEdit]);
 
   useEffect(() => {
     setAddress();
-  }, [setAddress]);
+  }, [setAddress, location, isEdit]);
 
   const [position, setPosition] = useState({
     lat: location?.lat,

--- a/src/components/Map/MapWithClickEvent.jsx
+++ b/src/components/Map/MapWithClickEvent.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState } from "react";
 import styled from "styled-components";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { CENTER } from "@/constant/map";
 import { MapMarker, Map } from "react-kakao-maps-sdk";
 
@@ -9,6 +9,7 @@ const MapWithClickEvent = ({ location }) => {
   const dispatch = useDispatch();
   const [roadAddress, setRoadAddress] = useState("");
   const [streetAddress, setStreetAddress] = useState("");
+  const { isEdit } = useSelector((state) => state.edit);
 
   let geocoder = new kakao.maps.services.Geocoder();
 
@@ -86,12 +87,14 @@ const MapWithClickEvent = ({ location }) => {
         center={{ lat: CENTER.LATITUDE, lng: CENTER.LONGITUDE }}
         level={4}
         onClick={(_, mouseEvent) => {
-          const latlng = mouseEvent.latLng;
-          setPosition({
-            lat: latlng.getLat(),
-            lng: latlng.getLng(),
-          });
-          getPosition(mouseEvent);
+          if (isEdit) {
+            const latlng = mouseEvent.latLng;
+            setPosition({
+              lat: latlng.getLat(),
+              lng: latlng.getLng(),
+            });
+            getPosition(mouseEvent);
+          }
         }}
       >
         <MapMarker position={position}>

--- a/src/components/common/button/ScrapBtn.jsx
+++ b/src/components/common/button/ScrapBtn.jsx
@@ -7,7 +7,7 @@ const ScrapBtn = ({ onClick, scrap, className }) => {
 
   return (
     <section onClick={onClick} className={className}>
-      {isLogin && scrap ? <StyledFill /> : isLogin && <StyledOut />}
+      {isLogin && (scrap ? <StyledFill /> : <StyledOut />)}
     </section>
   );
 };

--- a/src/components/createDocument/CreateDocument.jsx
+++ b/src/components/createDocument/CreateDocument.jsx
@@ -85,7 +85,7 @@ const CreateDocument = () => {
       <Container onSubmit={handleSubmit(onSubmit)} display={display}>
         <BottomSheet onClick={handleOnDisplay} />
         <DocsInput
-          type={DOCS_INFO.NAME}
+          name={DOCS_INFO.NAME}
           placeholder={HELPER_MSG.NAME}
           requiredMsg={ERROR_MSG.NAME}
           isLogin={isLogin}
@@ -95,7 +95,7 @@ const CreateDocument = () => {
         </DocsInput>
 
         <DocsInput
-          type={DOCS_INFO.LOCATION}
+          name={DOCS_INFO.LOCATION}
           placeholder={HELPER_MSG.LOCATION}
           value={inputAddress || ""}
           disabled

--- a/src/components/createDocument/DocumentInputGroup.jsx
+++ b/src/components/createDocument/DocumentInputGroup.jsx
@@ -6,15 +6,13 @@ import DocumentLabel from "@/components/document/DocumentLabel";
 import DocumentInput from "./DocumentInput";
 
 const DocumentInputGroup = ({
-  type,
+  name,
   children,
   requiredMsg,
   className,
   defaultInfo,
-  registerName = type,
   isLogin = true,
   isEdit = true,
-  location,
   ...inputProps
 }) => {
   const {
@@ -24,28 +22,30 @@ const DocumentInputGroup = ({
 
   return (
     <section className={className}>
-      <DocumentLabel htmlFor={type}>{children}</DocumentLabel>
+      <DocumentLabel htmlFor={name}>{children}</DocumentLabel>
       <Container>
         {isEdit ? (
-          <DocumentInput
-            id={type}
-            name={registerName}
-            defaultValue={defaultInfo}
-            register={
-              isLogin &&
-              register(registerName, {
-                required: requiredMsg,
-              })
-            }
-            {...inputProps}
-          />
+          <>
+            <DocumentInput
+              id={name}
+              name={name}
+              defaultValue={defaultInfo}
+              register={
+                isLogin &&
+                register(name, {
+                  required: requiredMsg,
+                })
+              }
+              {...inputProps}
+            />
+            {name === "docsRequestLocation" && (
+              <Help>지도에서 바꾸고자 하는 위치를 클릭하세요.</Help>
+            )}
+          </>
         ) : (
           <DocsContent>{defaultInfo}</DocsContent>
         )}
-        {location && isEdit && (
-          <Help>지도에서 바꾸고자 하는 위치를 클릭하세요.</Help>
-        )}
-        <ErrorMsg errors={errors} name={registerName} />
+        <ErrorMsg errors={errors} name={name} />
       </Container>
     </section>
   );
@@ -68,6 +68,7 @@ const DocsContent = styled.p`
 const Help = styled.p`
   margin-top: 0.4rem;
   font-size: 0.8rem;
+  display: block;
 `;
 
 export default DocumentInputGroup;

--- a/src/components/docsList/DocsItem.jsx
+++ b/src/components/docsList/DocsItem.jsx
@@ -27,7 +27,7 @@ const DocsItem = ({
             <Title>{name}</Title>
             <ScrapBtn onClick={handleOnScrapFill} scrap={scrap} />
           </div>
-          <span className="category">{category}</span>
+          <Category className="category">{category}</Category>
           <StyledHr />
         </Container>
       ) : (
@@ -38,7 +38,11 @@ const DocsItem = ({
 };
 
 const Title = styled.p`
-  font-weight: 500;
+  font-weight: 800;
+`;
+
+const Category = styled.span`
+  color: gray;
 `;
 
 export default DocsItem;

--- a/src/components/document/Basic.jsx
+++ b/src/components/document/Basic.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
@@ -9,110 +9,78 @@ import SelectInput from "@/components/common/input/SelectInput";
 import ScrapBtn from "@/components/common/button/ScrapBtn";
 import { basicModify } from "@/services/document";
 import "react-toastify/dist/ReactToastify.css";
-import { nullTokenEdit, adminApproval } from "@/utils/toast";
+import { adminApproval } from "@/utils/toast";
 import useDocsMutation from "@/hooks/useDocsMutation";
-import { ERROR_MSG, CATEGORY, DOCS_INFO } from "@/constant/document/create";
+import { ERROR_MSG, CATEGORY } from "@/constant/document/create";
 import DocumentInputGroup from "@/components/createDocument/DocumentInputGroup";
 import useScrap from "@/hooks/useScrap";
 
 const Basic = ({ data }) => {
-  const { isLogin } = useSelector((state) => state.user);
-
-  const {
-    id,
-    docsName,
-    docsLocation,
-    docsCategory,
-    scrap: isScraped,
-  } = data || {};
-
+  const dispatch = useDispatch();
+  const { id: docsId, docsName, docsCategory, scrap: isScraped } = data || {};
   const { latitude: getLat, longitude: getLng } = useSelector(
     (state) => state.latLng
   );
-
   let { address, initialAddress } = useSelector((state) => state.address);
-  let addressInfo = { lat: getLat, lng: getLng };
 
-  const [isEditBasic, setIsEditBasic] = useState(false);
+  const { isEdit } = useSelector((state) => state.edit);
   const [editAddress, setEditAddress] = useState(initialAddress);
 
   const { mutate: mutationBasicModify } = useDocsMutation(basicModify);
-  const { scraped, handleOnScrapFill } = useScrap(isScraped, id);
+  const { handleOnScrapFill } = useScrap(isScraped, docsId);
 
   const methods = useForm();
   const { handleSubmit, setValue, getValues, reset } = methods;
-
-  const handleSetInput = () => {
-    if (!isLogin) return nullTokenEdit();
-    setIsEditBasic(true);
-  };
-
-  const getAddressInfo = () => {
-    if (!getLat) {
-      addressInfo = docsLocation;
-    }
-    return addressInfo;
-  };
-
-  const saveBasicInfo = () => {
-    setValue("docsId", id);
-    setValue("docsRequestType", "MODIFIED");
-    setValue("docsRequestLocation", getAddressInfo());
-
-    mutationBasicModify(getValues(), {
-      onSuccess: () => adminApproval(),
-      onError: () => setEditAddress(initialAddress),
-    });
-  };
-
-  const handleBasicSave = () => {
-    setIsEditBasic(false);
-    saveBasicInfo();
-  };
-
-  useEffect(() => {
-    if (editAddress) {
-      methods.setValue(
-        "docsRequestLocation",
-        typeof editAddress === "string" ? editAddress : { getLat, getLng }
-      );
-    }
-  }, [methods, editAddress, getLat, getLng]);
 
   useEffect(() => {
     setEditAddress(address);
   }, [address]);
 
-  const handleBasicCancel = () => {
-    setIsEditBasic(false);
+  const clickSave = () => {
+    dispatch({ type: "disableEdit" });
+
+    setValue("docsId", docsId);
+    setValue("docsRequestType", "MODIFIED");
+    setValue("docsRequestLocation", { lat: getLat, lng: getLng });
+
+    mutationBasicModify(getValues(), {
+      onSuccess: () => {
+        setEditAddress(address);
+        adminApproval();
+      },
+      onError: () => setEditAddress(initialAddress),
+    });
+  };
+
+  const clickCancel = () => {
+    dispatch({ type: "disableEdit" });
     reset();
     setEditAddress(initialAddress);
-    // TODO: 마커 초기화
   };
 
   useEffect(() => {
-    setIsEditBasic(false);
-  }, [data, setIsEditBasic]);
+    // TODO: search 로직에분리
+    dispatch({ type: "disableEdit" });
+  }, [data, dispatch]);
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={handleSubmit(handleBasicSave)}>
+      <form onSubmit={handleSubmit(clickSave)}>
         <BasicInfo>
           <DocumentHeading
-            isEdit={isEditBasic}
-            clickEdit={handleSetInput}
-            clickCancel={handleBasicCancel}
+            isEdit={isEdit}
+            clickEdit={() => dispatch({ type: "enableEdit" })}
+            clickCancel={clickCancel}
           >
             기본 정보
           </DocumentHeading>
-          <ScrapBtn onClick={handleOnScrapFill} scrap={scraped} />
+          <ScrapBtn onClick={handleOnScrapFill} scrap={isScraped} />
         </BasicInfo>
 
         <Box>
           <EditName
-            type={DOCS_INFO.NAME}
-            registerName="docsRequestName"
-            isEdit={isEditBasic}
+            name="docsRequestName"
+            isEdit={isEdit}
             requiredMsg={ERROR_MSG.NAME}
             placeholder={docsName}
             defaultInfo={docsName}
@@ -121,25 +89,24 @@ const Basic = ({ data }) => {
           </EditName>
 
           <EditName
-            type={DOCS_INFO.LOCATION}
-            registerName="docsRequestLocation"
-            isEdit={isEditBasic}
-            defaultInfo={initialAddress}
+            name="docsRequestLocation"
+            isEdit={isEdit}
+            defaultInfo={editAddress ?? initialAddress}
             value={editAddress}
-            location
             disabled
           >
             위치
           </EditName>
 
           <DocsInfo>
-            <DocumentLabel htmlFor="docsCategory">카테고리</DocumentLabel>
+            <DocumentLabel htmlFor="docsRequestCategory">
+              카테고리
+            </DocumentLabel>
             <Container>
-              {isEditBasic ? (
+              {isEdit ? (
                 <SelectInput
-                  id="docsCategory"
-                  selected={docsCategory}
                   name="docsRequestCategory"
+                  selected={docsCategory}
                   list={CATEGORY}
                 />
               ) : (
@@ -166,7 +133,7 @@ const DocsInfo = styled.section`
 `;
 
 const Box = styled.section`
-  margin: 1rem 0 3rem 0;
+  margin: 1rem 0 3.5rem 0;
 `;
 
 const DocsContent = styled.article`

--- a/src/components/document/Basic.jsx
+++ b/src/components/document/Basic.jsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
 import DocumentHeading from "./DocumentHeading";
@@ -14,6 +14,7 @@ import useDocsMutation from "@/hooks/useDocsMutation";
 import { ERROR_MSG, CATEGORY } from "@/constant/document/create";
 import DocumentInputGroup from "@/components/createDocument/DocumentInputGroup";
 import useScrap from "@/hooks/useScrap";
+import { useWebSocket } from "@/hooks/useWebSocket";
 
 const Basic = ({ data }) => {
   const dispatch = useDispatch();
@@ -22,19 +23,13 @@ const Basic = ({ data }) => {
     (state) => state.latLng
   );
   let { address, initialAddress } = useSelector((state) => state.address);
-
   const { isEdit } = useSelector((state) => state.edit);
-  const [editAddress, setEditAddress] = useState(initialAddress);
 
   const { mutate: mutationBasicModify } = useDocsMutation(basicModify);
   const { handleOnScrapFill } = useScrap(isScraped, docsId);
 
   const methods = useForm();
   const { handleSubmit, setValue, getValues, reset } = methods;
-
-  useEffect(() => {
-    setEditAddress(address);
-  }, [address]);
 
   const clickSave = () => {
     dispatch({ type: "disableEdit" });
@@ -45,23 +40,23 @@ const Basic = ({ data }) => {
 
     mutationBasicModify(getValues(), {
       onSuccess: () => {
-        setEditAddress(address);
         adminApproval();
       },
-      onError: () => setEditAddress(initialAddress),
     });
   };
 
   const clickCancel = () => {
     dispatch({ type: "disableEdit" });
     reset();
-    setEditAddress(initialAddress);
+    dispatch({ type: "getAddress", payload: { address: initialAddress } });
   };
 
   useEffect(() => {
     // TODO: search 로직에분리
     dispatch({ type: "disableEdit" });
   }, [data, dispatch]);
+
+  // useWebSocket(data?.id, isEdit);
 
   return (
     <FormProvider {...methods}>
@@ -91,8 +86,8 @@ const Basic = ({ data }) => {
           <EditName
             name="docsRequestLocation"
             isEdit={isEdit}
-            defaultInfo={editAddress ?? initialAddress}
-            value={editAddress}
+            defaultInfo={initialAddress}
+            value={address}
             disabled
           >
             위치

--- a/src/components/document/Content.jsx
+++ b/src/components/document/Content.jsx
@@ -16,12 +16,12 @@ const Content = ({ data }) => {
 
   const { mutate: mutationContentModify } = useDocsMutation(contentModify);
 
-  const handleInputContent = () => {
+  const clickEdit = () => {
     setIsEditContent(true);
     setContentValue(docsContent);
   };
 
-  const handleContentSave = () => {
+  const clickSave = () => {
     setIsEditContent(false);
     mutationContentModify(
       { docs_id: id, docsContent: contentValue },
@@ -40,8 +40,8 @@ const Content = ({ data }) => {
       <ContentHeading>
         <DocumentHeading
           isEdit={isEditContent}
-          clickEdit={handleInputContent}
-          clickSave={handleContentSave}
+          clickEdit={clickEdit}
+          clickSave={clickSave}
           clickCancel={() => setIsEditContent(false)}
         >
           내용

--- a/src/components/document/Content.jsx
+++ b/src/components/document/Content.jsx
@@ -7,6 +7,7 @@ import DocumentTime from "./DocumentTime";
 import { contentModify } from "@/services/document";
 import { successEdit } from "@/utils/toast";
 import useDocsMutation from "@/hooks/useDocsMutation";
+import { useWebSocket } from "@/hooks/useWebSocket";
 
 const Content = ({ data }) => {
   const { id, docsContent, docsModifiedAt } = data || {};
@@ -35,6 +36,8 @@ const Content = ({ data }) => {
     setIsEditContent(false);
   }, [data, setIsEditContent]);
 
+  // useWebSocket(data?.id, isEditContent);
+
   return (
     <>
       <ContentHeading>
@@ -53,6 +56,20 @@ const Content = ({ data }) => {
         <EditorContainer data-color-mode="light" className="container">
           <MDEditor
             height={250}
+            previewOptions={{
+              allowedElements: [
+                "h1",
+                "h2",
+                "h3",
+                "h4",
+                "h5",
+                "h6",
+                "p",
+                "a",
+                "span",
+                "br",
+              ],
+            }}
             value={contentValue}
             onChange={setContentValue}
             preview="edit"

--- a/src/components/document/Content.jsx
+++ b/src/components/document/Content.jsx
@@ -1,17 +1,14 @@
 import styled from "styled-components";
-import { useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 import MDEditor from "@uiw/react-md-editor";
 
 import DocumentHeading from "./DocumentHeading";
 import DocumentTime from "./DocumentTime";
 import { contentModify } from "@/services/document";
-import { nullTokenEdit, successEdit } from "@/utils/toast";
+import { successEdit } from "@/utils/toast";
 import useDocsMutation from "@/hooks/useDocsMutation";
 
 const Content = ({ data }) => {
-  const { isLogin } = useSelector((state) => state.user);
-
   const { id, docsContent, docsModifiedAt } = data || {};
 
   const [contentValue, setContentValue] = useState(docsContent);
@@ -20,7 +17,6 @@ const Content = ({ data }) => {
   const { mutate: mutationContentModify } = useDocsMutation(contentModify);
 
   const handleInputContent = () => {
-    if (!isLogin) return nullTokenEdit();
     setIsEditContent(true);
     setContentValue(docsContent);
   };

--- a/src/components/document/DocumentHeading.jsx
+++ b/src/components/document/DocumentHeading.jsx
@@ -1,5 +1,6 @@
+import { nullTokenEdit } from "@/utils/toast";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
-
 const DocumentHeading = ({
   children,
   clickEdit,
@@ -7,9 +8,16 @@ const DocumentHeading = ({
   clickCancel,
   isEdit = false,
 }) => {
+  const { isLogin } = useSelector((state) => state.user);
+
+  const toggleEditAuth = () => {
+    if (!isLogin) return nullTokenEdit();
+    clickEdit();
+  };
+
   return (
     <Group>
-      <StyledHeading>{children}</StyledHeading>
+      <SectionTitle>{children}</SectionTitle>
       {isEdit ? (
         <>
           <button type="submit" className="icon save" onClick={clickSave}>
@@ -20,7 +28,7 @@ const DocumentHeading = ({
           </button>
         </>
       ) : (
-        <button type="button" className="icon" onClick={clickEdit}>
+        <button type="button" className="icon" onClick={toggleEditAuth}>
           편집
         </button>
       )}
@@ -43,7 +51,7 @@ const Group = styled.span`
   }
 `;
 
-const StyledHeading = styled.p`
+const SectionTitle = styled.p`
   font-size: 1.4rem;
   font-weight: 600;
 

--- a/src/components/document/DocumentLabel.jsx
+++ b/src/components/document/DocumentLabel.jsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 
 const DocumentLabel = ({ htmlFor, children }) => {
-  return <LabelStyled htmlFor={htmlFor}>{children}</LabelStyled>;
+  return <StyledLabel htmlFor={htmlFor}>{children}</StyledLabel>;
 };
 
-const LabelStyled = styled.label`
+const StyledLabel = styled.label`
   color: #216d32;
   font-size: 1.2rem;
   width: 7rem;

--- a/src/hooks/useDocsMutation.js
+++ b/src/hooks/useDocsMutation.js
@@ -3,10 +3,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 const useDocsMutation = (mutationFn) => {
   const queryClient = useQueryClient();
 
-  const { mutate, ...rest } = useMutation({
-    mutationFn,
+  const { mutate, ...rest } = useMutation(mutationFn, {
     onSuccess: () => {
-      queryClient.invalidateQueries("detail_document");
+      queryClient.invalidateQueries();
     },
     onError: (error) => {
       console.error(error);

--- a/src/hooks/useScrap.js
+++ b/src/hooks/useScrap.js
@@ -1,29 +1,23 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSelector } from "react-redux";
 
 import useDocsMutation from "./useDocsMutation";
 import { scrapCreate, scrapDelete } from "@/services/scrap";
 
-const useScrap = (isScraped, id) => {
+const useScrap = (isScraped, docsId) => {
   const [scraped, setScrap] = useState(isScraped);
   const { mutate: scrapDetailCreate } = useDocsMutation(scrapCreate);
   const { mutate: scrapDetailDelete } = useDocsMutation(scrapDelete);
   const { memberId } = useSelector((state) => state.user);
 
-  useEffect(() => {
-    setScrap(isScraped);
-  }, [isScraped]);
-
   const handleOnScrapFill = () => {
     setScrap((prev) => !prev);
-    if (!scraped) {
-      scrapDetailCreate({ memberId, docsId: id });
-    } else {
-      scrapDetailDelete({ memberId, docsId: id });
-    }
+
+    if (scraped) return scrapDetailDelete({ memberId, docsId });
+    return scrapDetailCreate({ memberId, docsId });
   };
 
-  return { scraped, handleOnScrapFill };
+  return { handleOnScrapFill };
 };
 
 export default useScrap;

--- a/src/services/index.jsx
+++ b/src/services/index.jsx
@@ -73,7 +73,7 @@ instance.interceptors.response.use(
     }
 
     if (status === 401) {
-      alert("로그인이 만료됐습니다. 다시 로그인 해주세요.");
+      alert("로그인이 필요합니다. 다시 로그인 해주세요.");
     }
 
     return Promise.reject(error.response);

--- a/src/store/editReducer.js
+++ b/src/store/editReducer.js
@@ -1,0 +1,20 @@
+const editState = {
+  isEdit: false,
+};
+
+const editReducer = (state = editState, action) => {
+  switch (action.type) {
+    case "enableEdit":
+      return {
+        isEdit: true,
+      };
+    case "disableEdit":
+      return {
+        isEdit: false,
+      };
+    default:
+      return state;
+  }
+};
+
+export default editReducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,6 +6,7 @@ import boundReducer from "./boundReducer";
 import userReducer from "./userReducer";
 import { persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage";
+import editReducer from "./editReducer";
 
 const persistConfig = {
   key: "root",
@@ -20,6 +21,7 @@ const rootReducer = combineReducers({
   address: addressReducer,
   SwNe: boundReducer,
   user: userReducer,
+  edit: editReducer,
 });
 
 // const store = createStore(rootReducer);


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

- 문서 상세 조회 리팩토링
- 편집<->저장,취소 상태 관리 개선
  - DocumentHeading 컴포넌트에 isLogin에 따라 상태 관리
- DocumentInputGorup props명 변경
- 주소 관리 로직 변경
  - 서버에서 받아오는 initialAddress와 마커에 따라 변하는 address 관련 로직 변경
  - [object Object] 관련 버그 수정
- 편집 상태에서만 지도위에 별도의 마커 표시 가능
  - 편집상태를 전역적으로 관리

## 관련 이슈

- closes #132 
