### PR TITLE
fix: 기본정보 편집 후 input에 계속 캐싱되어 있는 문제 해결

### DIFF
--- a/src/components/Map/MapWithClickEvent.jsx
+++ b/src/components/Map/MapWithClickEvent.jsx
@@ -63,6 +63,11 @@ const MapWithClickEvent = ({ location, isEdit }) => {
           type: "initialAddress",
           payload: { initialAddress: payloadAddress },
         });
+
+        dispatch({
+          type: "getAddress",
+          payload: { address: payloadAddress },
+        });
       }
     };
 

--- a/src/components/common/layout/Header.jsx
+++ b/src/components/common/layout/Header.jsx
@@ -16,7 +16,7 @@ const Header = ({ isDisplay }) => {
   return (
     <Container>
       <HeaderDiv>
-        <LogoImg src={mainLogo} alt="jnu-logo" onClick={reloadHome} />
+        <LogoImg src={mainLogo} alt="jnu-wiki logo" onClick={reloadHome} />
         <SearchBar isDisplay={isDisplay} />
       </HeaderDiv>
       <Line />

--- a/src/components/document/Basic.jsx
+++ b/src/components/document/Basic.jsx
@@ -32,8 +32,6 @@ const Basic = ({ data }) => {
   const { handleSubmit, setValue, getValues, reset } = methods;
 
   const handleSaveClick = () => {
-    dispatch({ type: "disableEdit" });
-
     setValue("docsId", docsId);
     setValue("docsRequestType", "MODIFIED");
     setValue("docsRequestLocation", { lat: getLat, lng: getLng });
@@ -41,18 +39,17 @@ const Basic = ({ data }) => {
     mutationBasicModify(getValues(), {
       onSuccess: () => {
         adminApproval();
+        handleReset();
       },
     });
   };
 
-  const handleCancelClick = () => {
+  const handleReset = () => {
     dispatch({ type: "disableEdit" });
     reset();
-    dispatch({ type: "getAddress", payload: { address: initialAddress } });
   };
 
   useEffect(() => {
-    // TODO: search 로직에분리
     dispatch({ type: "disableEdit" });
   }, [data, dispatch]);
 
@@ -65,7 +62,7 @@ const Basic = ({ data }) => {
           <DocumentHeading
             isEdit={isEdit}
             onEditClick={() => dispatch({ type: "enableEdit" })}
-            onCancelClick={handleCancelClick}
+            onCancelClick={handleReset}
           >
             기본 정보
           </DocumentHeading>

--- a/src/components/document/Basic.jsx
+++ b/src/components/document/Basic.jsx
@@ -33,7 +33,6 @@ const Basic = ({ data }) => {
 
   const handleSaveClick = () => {
     setValue("docsId", docsId);
-    setValue("docsRequestType", "MODIFIED");
     setValue("docsRequestLocation", { lat: getLat, lng: getLng });
 
     mutationBasicModify(getValues(), {

--- a/src/services/document.jsx
+++ b/src/services/document.jsx
@@ -36,16 +36,11 @@ export const docsList = ({
 };
 
 export const basicModify = (data) => {
-  const {
-    docsId,
-    docsRequestType,
-    docsRequestCategory,
-    docsRequestName,
-    docsRequestLocation,
-  } = data;
+  const { docsId, docsRequestCategory, docsRequestName, docsRequestLocation } =
+    data;
   return instance.post("/requests/update", {
     docsId,
-    docsRequestType,
+    docsRequestType: "MODIFIED",
     docsRequestCategory,
     docsRequestName,
     docsRequestLocation,


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 사항

-기본정보 수정 완료 후 검색을 통해 다른 문서로 접근하고 편집 하려 할 때, 이전의 문서 내용이 남아있는 문제를 해결
- 주소값: Map 컴포넌트에서 백엔드로부터 주소 불러올 때 address값도 초기화
- 제목/카테고리: mutation onSuccess 후 reset 하도록 설정

## 관련 이슈

- closes #171 
